### PR TITLE
Fixed missing break statement in AbsolutePoseSacProblem::TWOPT

### DIFF
--- a/src/sac_problems/absolute_pose/AbsolutePoseSacProblem.cpp
+++ b/src/sac_problems/absolute_pose/AbsolutePoseSacProblem.cpp
@@ -106,6 +106,7 @@ opengv::sac_problems::
     solution.block<3,3>(0,0) = rotation * R_bc.transpose();
 
     solutions.push_back(solution);
+    break;
   }
   case GP3P:
   {


### PR DESCRIPTION
Fixed missing break statement in AbsolutePoseSacProblem::TWOPT algorithm switch
