### PR TITLE
Fix Ubuntu installation instructions: eigen package does not exist

### DIFF
--- a/doc/addons/01_installation.dox
+++ b/doc/addons/01_installation.dox
@@ -35,7 +35,7 @@ sudo apt-get install build-essential
  *  <li>Install cmake, eigen3 and boost, those tools are required by the library. Type:
  *
 \verbatim
-sudo apt-get install cmake eigen libboost-all-dev
+sudo apt-get install cmake libeigen3-dev libboost-all-dev
 \endverbatim
  *
  *  CMake is a cross-platform, open-source build system used for pretty much anything in the compilation process but the compilation/linking itself. Eigen3 is a powerful linear algebra library used for all computations in OpenGV. Boost is a powerful C++ library which extends the functionality of the Standard Library.


### PR DESCRIPTION
```bash
$ sudo apt-get install eigen
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package eigen
```

```bash
$ sudo apt-get install libeigen3-dev 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libeigen3-dev is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```