### PR TITLE
CMake improvement: allow out of source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ set (OPENGV_VERSION_MINOR 0)
 set(CMAKE_BUILD_TYPE Release)
 
 #set the default path for built executables to the "bin" directory
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 #set the default path for built libraries to the "lib" directory
-set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 
 add_definitions (-Wall -march=native -O3) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
 


### PR DESCRIPTION
[Out of source](http://www.cmake.org/Wiki/CMake_FAQ#Out-of-source_build_trees) build is better.

The current `CMakeLists.txt` configuration is weird because it creates binaries and libraries within the source tree; thus polluting the source tree (especially true when using `git`)

This pull request allows to do out of source build, binaries and libraries should be built into [`CMAKE_BINARY_DIR`](http://www.cmake.org/Wiki/CMake_Useful_Variables)

Without the pull request:
---
```bash
$ ls
build  src # src contains git repository content
$ cmake ../src/
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dell/libraries/opengv/build
$ make -j4
[ 78%] Built target opengv
[ 82%] Built target random_generators
[ 83%] Built target test_absolute_pose
[ 84%] [ 86%] [ 86%] Built target test_eigensolver
Built target test_absolute_pose_sac
Built target test_eigensolver_sac
[ 87%] [ 88%] Built target test_multi_noncentral_relative_pose_sac
Built target test_noncentral_absolute_pose
[ 90%] Built target test_noncentral_relative_pose
[ 91%] Built target test_noncentral_absolute_pose_sac
[ 92%] Built target test_noncentral_relative_pose_sac
[ 93%] Built target test_point_cloud
[ 94%] Built target test_point_cloud_sac
[ 95%] Built target test_relative_pose
[ 96%] Built target test_relative_pose_rotationOnly_sac
[ 97%] [ 98%] Built target test_relative_pose_rotationOnly
Built target test_relative_pose_sac
[100%] Built target test_triangulation
$ ls ../src/ # The src directory is now polluted with bin/ and lib/
bin  CMakeLists.txt  doc  Doxyfile  include  lib  License.txt  Makefile.ros  manifest.xml  matlab  modules  README.txt  src  test  third_party
$ cd ../src/
$ git status # git is now polluted with build files!
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	bin/
	lib/

nothing added to commit but untracked files present (use "git add" to track)
```

With the pull request
---
```bash
$ ls
build  src # src contains git repository content
$ cd build/
$ cmake ../src/
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dell/libraries/opengv/build
dell@M6700:~/libraries/opengv/build$ make -j4
[ 78%] Built target opengv
[ 82%] Built target random_generators
[ 85%] [ 85%] [ 85%] [ 86%] Built target test_absolute_pose_sac
Built target test_absolute_pose
Built target test_eigensolver
Built target test_eigensolver_sac
[ 88%] [ 88%] [ 90%] [ 91%] Built target test_noncentral_relative_pose
Built target test_noncentral_absolute_pose_sac
Built target test_noncentral_absolute_pose
Built target test_multi_noncentral_relative_pose_sac
[ 92%] Built target test_point_cloud
[ 93%] [ 94%] Built target test_noncentral_relative_pose_sac
Built target test_point_cloud_sac
[ 95%] Built target test_relative_pose
[ 96%] Built target test_relative_pose_rotationOnly
[ 97%] [ 98%] Built target test_relative_pose_rotationOnly_sac
Built target test_triangulation
[100%] Built target test_relative_pose_sac
$ ls # bin/ and lib/ are now in the build directory / not polluting src tree
bin  CMakeCache.txt  CMakeFiles  cmake_install.cmake  lib  Makefile
```