### PR TITLE
[cmake] add install rule for headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,8 @@ install(
   COMPONENT library
 )
 
+install(DIRECTORY include/ DESTINATION include/ FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
+
 if (BUILD_PYTHON)
   add_subdirectory( python )
 endif()


### PR DESCRIPTION
The title says it all :-)

When installing the library it also add the `include` folder with the hierarchy of library headers.

Hope it helps!

S.