### PR TITLE
Link to Boost_LIBRARIES instead of a specific file

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,7 +22,7 @@ if(APPLE)
     set_target_properties(pyopengv PROPERTIES
         LINK_FLAGS "-undefined dynamic_lookup"
     )
-    target_link_libraries(pyopengv "${Boost_LIBRARY_DIR}/libboost_python.a")
+    target_link_libraries(pyopengv ${Boost_LIBRARIES})
 else()
     target_link_libraries(pyopengv
         ${Boost_LIBRARIES}


### PR DESCRIPTION
On OSX, the python module was linking to the static boost_python lib. That is not needed. Now, it links to whatever Boost_LIBRARIES defines.

Fixes https://github.com/laurentkneip/opengv/issues/27