### PR TITLE
[cmake] remove INSTALL_OPENGV option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ OPTION(BUILD_TESTS "Build tests" ON)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 OPTION(BUILD_PYTHON "Build Python extension" OFF)
 OPTION(BUILD_POSITION_INDEPENDENT_CODE "Build position independent code (-fPIC)" ON)
-OPTION(INSTALL_OPENGV "Install OpenGV on the system" OFF)
 
 add_definitions (-Wall -march=native -O3) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
 
@@ -300,14 +299,12 @@ IF (BUILD_TESTS)
 
 ENDIF()
 
-IF (INSTALL_OPENGV)
-  install(
-    TARGETS opengv
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    COMPONENT library
-  )
-ENDIF()
+install(
+  TARGETS opengv
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  COMPONENT library
+)
 
 install(DIRECTORY include/ DESTINATION include/ FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
 

--- a/src/absolute_pose/methods.cpp
+++ b/src/absolute_pose/methods.cpp
@@ -545,7 +545,7 @@ transformations_t upnp(
   
   //Round 1: chirality check
   std::vector<std::pair<double,Eigen::Vector4d>,Eigen::aligned_allocator< std::pair<double,Eigen::Vector4d> > > quaternions2;
-  for( int i = 0; i < quaternions1.size(); i++ )
+  for( std::size_t i = 0; i < quaternions1.size(); i++ )
   {
     rotation_t Rinv = math::quaternion2rot(quaternions1[i].second);
     
@@ -563,7 +563,7 @@ transformations_t upnp(
     
     int count_negative = 0;
     
-    for( int j = 0; j < (int) indices.size(); j++ )
+    for( std::size_t j = 0; j <  indices.size(); j++ )
     {
       Eigen::Matrix<double,3,1> f = adapter.getCamRotation(indices[j]) * adapter.getBearingVector(indices[j]);
       Eigen::Matrix<double,3,1> p = adapter.getPoint(indices[j]);


### PR DESCRIPTION
Hi,

I made a small fix in cmake files to avoid the inconsistency between headers installation and libs installation when calling:

```
cmake && make && make install
```

with the default cmake options.

"install" is already a cmake target so it is useless to have an option to disable this dedicated target. If someone don't want to install, he can just avoid to call "make install".

Regards,
Fabien
