### PR TITLE
Some cmake improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ before_script:
   - cd build
   - >
      if [ $CXX = "clang++" ]; then
-        cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF -DCMAKE_CXX_FLAGS="-Wno-deprecated-register"
+        cmake .. -DBUILD_TESTS:BOOL=ON -DBUILD_PYTHON:BOOL=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-register"
      else
-        cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF
+        cmake .. -DBUILD_TESTS:BOOL=ON -DBUILD_PYTHON:BOOL=ON
      fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,12 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF
+  - >
+     if [ $CXX = "clang++" ]; then
+        cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF -DCMAKE_CXX_FLAGS="-Wno-deprecated-register"
+     else
+        cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF
+     fi
 
 script:
   - make -j2 VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 
 language: cpp
 
@@ -5,16 +7,51 @@ compiler:
   - clang
   - gcc
 
-before_install:
-  - sudo apt-get update
+cache:
+  apt: true
 
-install:
-  - sudo apt-get install -y build-essential cmake git python-dev libboost-python-dev python-numpy libeigen3-dev
+addons:
+  apt:
+    packages:
+        - build-essential 
+        - python-dev 
+        - libboost-python-dev 
+        - python-numpy-dev
+        - libeigen3-dev
+
+env:
+  global:
+    # CMAKE minimal required version 3.1.0
+    - CMAKE_URL="https://cmake.org/files/v3.1/cmake-3.1.3-Linux-x86_64.tar.gz"
+    - CMAKE_ROOT=${TRAVIS_BUILD_DIR}/cmake
+    - CMAKE_SOURCE=${CMAKE_ROOT}/source
+    - CMAKE_INSTALL=${CMAKE_ROOT}/install
+
+before_install:
+ # CMAKE most recent version
+ - >
+    if [ "$(ls -A ${CMAKE_INSTALL})" ]; then
+      echo "CMake found in cache.";
+      ls -A ${CMAKE_INSTALL}
+      export PATH=${CMAKE_INSTALL}/bin:${PATH};
+      cmake --version
+    else
+      mkdir --parent ${CMAKE_SOURCE}
+      mkdir --parent ${CMAKE_INSTALL}
+      ls -A ${CMAKE_INSTALL}
+      travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${CMAKE_INSTALL}
+      export PATH=${CMAKE_INSTALL}/bin:${PATH};
+      cmake --version
+    fi
+
 
 before_script:
   - mkdir build
   - cd build
-  - cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=ON
+  - cmake .. -DBUILD_TESTS=ON -DBUILD_PYTHON=OFF
 
 script:
-  - make -j2
+  - make -j2 VERBOSE=1
+cache:
+  directories:
+    - $CMAKE_INSTALL

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ before_script:
 
 script:
   - make -j2 VERBOSE=1
+  - make test
+
 cache:
   directories:
     - $CMAKE_INSTALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ ADD_DEFINITIONS (
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules/")
 find_package(Eigen REQUIRED)
 set(ADDITIONAL_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS} ${EIGEN_INCLUDE_DIR}/unsupported)
-include_directories(${PROJECT_SOURCE_DIR}/include)
 
 set( OPENGV_SOURCE_FILES
   src/absolute_pose/modules/main.cpp
@@ -179,7 +178,14 @@ set_target_properties( opengv random_generators PROPERTIES
                     DEBUG_POSTFIX d )
 
 target_include_directories( opengv PUBLIC 
+                # only when building from the source tree
+                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                # only when using the lib from the install path
+                $<INSTALL_INTERFACE:include>
+                ${ADDITIONAL_INCLUDE_DIRS} )
+
 target_include_directories( random_generators PRIVATE ${ADDITIONAL_INCLUDE_DIRS} )
+
 target_link_libraries( random_generators opengv )
 
 IF (BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1.3)
 project(opengv VERSION 1.0 LANGUAGES CXX)
 
 # Set the build type.  Options are:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,13 +282,13 @@ IF (BUILD_TESTS)
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     COMMAND test_point_cloud)
 
-  add_Executable( test_point_cloud_sac test/test_point_cloud_sac.cpp )
+  add_executable( test_point_cloud_sac test/test_point_cloud_sac.cpp )
   target_link_libraries( test_point_cloud_sac opengv random_generators )
   add_test(NAME test_point_cloud_sac
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     COMMAND test_point_cloud_sac)
 
-  add_Executable( test_Sturm test/test_Sturm.cpp )
+  add_executable( test_Sturm test/test_Sturm.cpp )
   target_link_libraries( test_Sturm opengv random_generators )
   add_test(NAME test_Sturm
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.1.0)
-project(opengv CXX)
-
-set (OPENGV_VERSION_MAJOR 1)
-set (OPENGV_VERSION_MINOR 0)
+project(opengv VERSION 1.0 LANGUAGES CXX)
 
 # Set the build type.  Options are:
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,17 +328,54 @@ IF (BUILD_TESTS)
 
 ENDIF()
 
-install(
-  TARGETS opengv
-  EXPORT opengv-export
-  RUNTIME DESTINATION bin
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  COMPONENT library
-)
-target_include_directories(opengv PUBLIC "${CMAKE_INSTALL_PREFIX}/include")
-install(DIRECTORY include/ DESTINATION include/ FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
-install(EXPORT opengv-export DESTINATION CMake FILE opengv-config.cmake)
+# Configuration
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion )
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+    "modules/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}")
+
+# Targets:
+install(TARGETS opengv
+        EXPORT "${targets_export_name}"
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "${include_install_dir}")
+
+# Config
+#   * <prefix>/lib/cmake/opengv/opengvConfig.cmake
+#   * <prefix>/lib/cmake/opengv/opengvConfigVersion.cmake
+install(FILES "${project_config}" "${version_config}"
+        DESTINATION "${config_install_dir}")
+
+# Config
+#   * <prefix>/lib/cmake/opengv/opengvTargets.cmake
+install(EXPORT "${targets_export_name}"
+        NAMESPACE "${namespace}"
+        DESTINATION "${config_install_dir}")
+
+# Headers
+install(DIRECTORY include/ 
+        DESTINATION ${include_install_dir} 
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
 
 
 if (BUILD_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,10 +172,13 @@ set( OPENGV_HEADER_FILES
 add_library( opengv ${OPENGV_SOURCE_FILES} ${OPENGV_HEADER_FILES} )
 add_library( random_generators test/random_generators.cpp test/random_generators.hpp test/experiment_helpers.cpp test/experiment_helpers.hpp test/time_measurement.cpp test/time_measurement.hpp )
 set_target_properties( opengv random_generators PROPERTIES
-  CXX_STANDARD 11
-  CXX_STANDARD_REQUIRED ON
-  DEBUG_POSTFIX d )
-target_include_directories( opengv PUBLIC ${ADDITIONAL_INCLUDE_DIRS} )
+                    SOVERSION ${PROJECT_VERSION}
+                    VERSION ${PROJECT_VERSION}
+                    CXX_STANDARD 11
+                    CXX_STANDARD_REQUIRED ON
+                    DEBUG_POSTFIX d )
+
+target_include_directories( opengv PUBLIC 
 target_include_directories( random_generators PRIVATE ${ADDITIONAL_INCLUDE_DIRS} )
 target_link_libraries( random_generators opengv )
 

--- a/include/opengv/sac/implementation/SampleConsensusProblem.hpp
+++ b/include/opengv/sac/implementation/SampleConsensusProblem.hpp
@@ -29,6 +29,7 @@
  ******************************************************************************/
 
 //Note: has been derived from ROS
+#include <functional>
 
 template<typename M>
 opengv::sac::SampleConsensusProblem<M>::SampleConsensusProblem(

--- a/modules/Config.cmake.in
+++ b/modules/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/modules/FindNumPy.cmake
+++ b/modules/FindNumPy.cmake
@@ -49,7 +49,9 @@ if(NOT PYTHONINTERP_FOUND)
     set(NUMPY_FOUND FALSE)
     return()
 endif()
-
+if($ENV{TRAVIS})
+  set(PYTHON_EXECUTABLE "/usr/bin/python")
+endif()
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
     "import numpy as n; print(n.__version__); print(n.get_include());"
     RESULT_VARIABLE _NUMPY_SEARCH_SUCCESS

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,9 +13,10 @@ add_library( pyopengv SHARED pyopengv.cpp )
 target_link_libraries(pyopengv opengv)
 
 set_target_properties(pyopengv PROPERTIES
-    PREFIX ""
-    SUFFIX ".so"
-)
+                    CXX_STANDARD 11
+                    CXX_STANDARD_REQUIRED ON
+                    PREFIX ""
+                    SUFFIX ".so")
 if(APPLE)
     set_target_properties(pyopengv PROPERTIES
         LINK_FLAGS "-undefined dynamic_lookup"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -15,6 +15,8 @@ target_link_libraries(pyopengv opengv)
 set_target_properties(pyopengv PROPERTIES
                     CXX_STANDARD 11
                     CXX_STANDARD_REQUIRED ON
+                    SOVERSION ${PROJECT_VERSION}
+                    VERSION ${PROJECT_VERSION}
                     PREFIX ""
                     SUFFIX ".so")
 if(APPLE)


### PR DESCRIPTION
Hi Laurent,

this PR add some improvements (I hope..) to the cmake building system, but it does not break any compatibility with the previous version (ie building, installation and use as 3rd party is the same as before, hopefully more robust). In particular:
* the minimal version for cmake is raised to 3.1.3 instead of 3.1.0 because of a cmake bug in managing `CMAKE_CXX_STANDARD 11` properties ([here](https://cmake.org/Bug/view.php?id=15355) the ref to the bug).
* There is now a template for the `opengvConfig.cmake`, which allows to automagically load the proper `opengvTargets[Release, Debug].cmake` according to the build configuration. This way, e.g. one can install all the library configurations in the same place and the host will grab the needed one.
* It uses `target_include_directories()`, which is preferable over `include_directories()` for properly propagating the includes when the lib is used as 3rd party.
* There are some other minor improvements that better exploits the features of cmake > 3.0, eg the version is declared directly in `project()`, which automatically sets the various `PROJECT_VERSION_MAJOR` etc.. variables (see  [here](https://cmake.org/cmake/help/v3.0/command/project.html) for reference).
* It also brings back to life and updates the `.travis.yml` for continuous integration, everything builds fine now, both with clang 3.5 and gcc 4.8.4. I had to use a [dirty hack](https://github.com/alicevision/opengv/blob/cmakeInstall/modules/FindNumPy.cmake#L52) in `FindNumpy` as apparently the executable tested inside the function has no visibility over the system modules (?). Maybe @paulinus can find a better solution? :-) See [here](https://travis-ci.org/alicevision/opengv/builds) for an example of working building on travis.

I hope it helps.

Cheers

Simone