### PR TITLE
Add bash script for automatic MEX compilation in Linux

### DIFF
--- a/matlab/make_mex.sh
+++ b/matlab/make_mex.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Generate MEX files by compiling from Matlab
+# This scripts intends to automate the compilation process
+# by following the instructions provided in
+# http://laurentkneip.github.io/opengv/page_installation.html#sec_installation_5
+# We assume the installation configuration is standard
+# so that every dependency can be found in an automated way
+
+# We assume a launcher command is available: matlab
+# Add OpenGV library directory to the path
+export LD_LIBRARY_PATH=../build/lib:$LD_LIBRARY_PATH
+
+# Find path to Eigen library (assumes CMake has cached EIGEN_INCLUDE_DIRS)
+# See https://stackoverflow.com/questions/8474753/how-to-get-a-cmake-variable-from-the-command-line
+EigenPath=$(cmake -L ../build | grep EIGEN_INCLUDE_DIRS | cut -d "=" -f2)
+
+# Call Matlab with the compilation command
+matlab -nodisplay -nosplash -nodesktop \
+-r "mex -I../include -I${EigenPath} -L../build/lib -lopengv opengv.cpp -cxx, mex -I../include -I${EigenPath} -L../build/lib -lopengv opengv_donotuse.cpp -cxx, exit"
+
+


### PR DESCRIPTION
At some point in history, Eigen was removed as a thirdparty,
so the [instructions for compiling Matlab wrappers](http://laurentkneip.github.io/opengv/page_installation.html#sec_installation_5) are now outdated.
Now, you need to set the include path for Eigen depending on your particular system,
e.g. `mex -I../include -I/usr/include/eigen3 -L../build/lib -lopengv opengv.cpp -cxx`

I created an executable script `make_mex.sh` that internally performs all the required steps
(at least for Linux). In particular it searches in the Cmake cache to read the path for Eigen.
Finally the scripts calls matlab from the command line to compile the MEX files for
*opengv.cpp* and *opengv_donotuse.cpp*.