### PR TITLE
Ignore some patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 lib
+build
+*.mexa64


### PR DESCRIPTION
Ignore some compilation files:
- The build (compilation) directory
- The *.mexa64 files for Matlab wrapper