### PR TITLE
Use Boost Python NumPy for recent versions of Boost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 lib
+.vscode
+*.pyc

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-find_package(Boost REQUIRED COMPONENTS python)
+find_package(Boost COMPONENTS python-py35 REQUIRED)
 
 if(${Boost_VERSION} LESS 106300)
     message("Not using boost/python/numpy.")
@@ -12,7 +12,6 @@ else()
     find_package(Boost 1.63 REQUIRED COMPONENTS python numpy)
 endif()
 
-find_package(Boost COMPONENTS python-py35 REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 set(Python_ADDITIONAL_VERSIONS "3.5")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,18 @@
 
-find_package(Boost COMPONENTS python REQUIRED)
+
+find_package(Boost REQUIRED COMPONENTS python)
+
+if(${Boost_VERSION} LESS 106300)
+    message("Not using boost/python/numpy.")
+    set(USE_BOOST_PYTHON_NUMPY "off")
+else()
+    message("Using boost/python/numpy.")
+    set(USE_BOOST_PYTHON_NUMPY "on")
+    add_definitions(-DUSE_BOOST_PYTHON_NUMPY)
+
+    find_package(Boost 1.63 REQUIRED COMPONENTS python numpy)
+endif()
+
 include_directories(${Boost_INCLUDE_DIRS})
 
 set(Python_ADDITIONAL_VERSIONS "2.7")

--- a/python/pyopengv.cpp
+++ b/python/pyopengv.cpp
@@ -13,8 +13,10 @@
 
 #include "types.hpp"
 
+#ifndef USE_BOOST_PYTHON_NUMPY
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/ndarrayobject.h>
+#endif
 
 #if (PY_VERSION_HEX < 0x03000000)
 static void numpy_import_array_wrapper()
@@ -28,11 +30,8 @@ static int* numpy_import_array_wrapper()
 
 
 
-
 namespace pyopengv {
 
-namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
 
 typedef PyArrayContiguousView<double> pyarray_t;
 
@@ -67,21 +66,18 @@ bp::object arrayFromPoints( const opengv::points_t &points )
     data[3 * i + 1] = points[i][1];
     data[3 * i + 2] = points[i][2];
   }
-  npy_intp shape[2] = {(npy_intp)points.size(), 3};
-  return bpn_array_from_data(2, shape, &data[0]);
+  return bpn_array_from_data(&data[0], points.size(), 3);
 }
 
 bp::object arrayFromTranslation( const opengv::translation_t &t )
 {
-  npy_intp shape[1] = {3};
-  return bpn_array_from_data(1, shape, t.data());
+  return bpn_array_from_data(t.data(), 3);
 }
 
 bp::object arrayFromRotation( const opengv::rotation_t &R )
 {
   Eigen::Matrix<double, 3, 3, Eigen::RowMajor> R_row_major = R;
-  npy_intp shape[2] = {3, 3};
-  return bpn_array_from_data(2, shape, R_row_major.data());
+  return bpn_array_from_data(R_row_major.data(), 3, 3);
 }
 
 bp::list listFromRotations( const opengv::rotations_t &Rs )
@@ -96,8 +92,7 @@ bp::list listFromRotations( const opengv::rotations_t &Rs )
 bp::object arrayFromEssential( const opengv::essential_t &E )
 {
   Eigen::Matrix<double, 3, 3, Eigen::RowMajor> E_row_major = E;
-  npy_intp shape[2] = {3, 3};
-  return bpn_array_from_data(2, shape, E_row_major.data());
+  return bpn_array_from_data(E_row_major.data(), 3, 3);
 }
 
 bp::list listFromEssentials( const opengv::essentials_t &Es )
@@ -112,8 +107,7 @@ bp::list listFromEssentials( const opengv::essentials_t &Es )
 bp::object arrayFromTransformation( const opengv::transformation_t &t )
 {
   Eigen::Matrix<double, 3, 4, Eigen::RowMajor> t_row_major = t;
-  npy_intp shape[2] = {3, 4};
-  return bpn_array_from_data(2, shape, t_row_major.data());
+  return bpn_array_from_data(t_row_major.data(), 3, 4);
 }
 
 bp::list listFromTransformations( const opengv::transformations_t &t )
@@ -146,16 +140,16 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CentralAbsoluteAdapter(
-      bpn::array & bearingVectors,
-      bpn::array & points )
+      ndarray &bearingVectors,
+      ndarray &points )
     : _bearingVectors(bearingVectors)
     , _points(points)
   {}
 
   CentralAbsoluteAdapter(
-      bpn::array & bearingVectors,
-      bpn::array & points,
-      bpn::array & R )
+      ndarray &bearingVectors,
+      ndarray &points,
+      ndarray &R )
     : _bearingVectors(bearingVectors)
     , _points(points)
   {
@@ -168,10 +162,10 @@ public:
   }
 
   CentralAbsoluteAdapter(
-      bpn::array & bearingVectors,
-      bpn::array & points,
-      bpn::array & t,
-      bpn::array & R )
+      ndarray &bearingVectors,
+      ndarray &points,
+      ndarray &t,
+      ndarray &R )
     : _bearingVectors(bearingVectors)
     , _points(points)
   {
@@ -222,59 +216,59 @@ protected:
 
 
 
-bp::object p2p( bpn::array &v, bpn::array &p, bpn::array &R )
+bp::object p2p( ndarray &v, ndarray &p, ndarray &R )
 {
   CentralAbsoluteAdapter adapter(v, p, R);
   return arrayFromTranslation(
     opengv::absolute_pose::p2p(adapter, 0, 1));
 }
 
-bp::object p3p_kneip( bpn::array &v, bpn::array &p )
+bp::object p3p_kneip( ndarray &v, ndarray &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::p3p_kneip(adapter, 0, 1, 2));
 }
 
-bp::object p3p_gao( bpn::array &v, bpn::array &p )
+bp::object p3p_gao( ndarray &v, ndarray &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::p3p_gao(adapter, 0, 1, 2));
 }
 
-bp::object gp3p( bpn::array &v, bpn::array &p )
+bp::object gp3p( ndarray &v, ndarray &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::gp3p(adapter, 0, 1, 2));
 }
 
-bp::object epnp( bpn::array &v, bpn::array &p )
+bp::object epnp( ndarray &v, ndarray &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return arrayFromTransformation(
     opengv::absolute_pose::epnp(adapter));
 }
 
-bp::object gpnp( bpn::array &v, bpn::array &p )
+bp::object gpnp( ndarray &v, ndarray &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return arrayFromTransformation(
     opengv::absolute_pose::gpnp(adapter));
 }
 
-bp::object upnp( bpn::array &v, bpn::array &p )
+bp::object upnp( ndarray &v, ndarray &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::upnp(adapter));
 }
 
-bp::object optimize_nonlinear( bpn::array &v,
-                               bpn::array &p,
-                               bpn::array &t,
-                               bpn::array &R )
+bp::object optimize_nonlinear( ndarray &v,
+                               ndarray &p,
+                               ndarray &t,
+                               ndarray &R )
 {
   CentralAbsoluteAdapter adapter(v, p, t, R);
   return arrayFromTransformation(
@@ -282,8 +276,8 @@ bp::object optimize_nonlinear( bpn::array &v,
 }
 
 bp::object ransac(
-    bpn::array &v,
-    bpn::array &p,
+    ndarray &v,
+    ndarray &p,
     std::string algo_name,
     double threshold,
     int max_iterations )
@@ -334,16 +328,16 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CentralRelativeAdapter(
-      bpn::array & bearingVectors1,
-      bpn::array & bearingVectors2 )
+      ndarray &bearingVectors1,
+      ndarray &bearingVectors2 )
     : _bearingVectors1(bearingVectors1)
     , _bearingVectors2(bearingVectors2)
   {}
 
   CentralRelativeAdapter(
-      bpn::array & bearingVectors1,
-      bpn::array & bearingVectors2,
-      bpn::array & R12 )
+      ndarray &bearingVectors1,
+      ndarray &bearingVectors2,
+      ndarray &R12 )
     : _bearingVectors1(bearingVectors1)
     , _bearingVectors2(bearingVectors2)
   {
@@ -356,10 +350,10 @@ public:
   }
 
   CentralRelativeAdapter(
-      bpn::array & bearingVectors1,
-      bpn::array & bearingVectors2,
-      bpn::array & t12,
-      bpn::array & R12 )
+      ndarray &bearingVectors1,
+      ndarray &bearingVectors2,
+      ndarray &t12,
+      ndarray &R12 )
     : _bearingVectors1(bearingVectors1)
     , _bearingVectors2(bearingVectors2)
   {
@@ -415,73 +409,73 @@ protected:
 };
 
 
-bp::object twopt( bpn::array &b1, bpn::array &b2, bpn::array &R )
+bp::object twopt( ndarray &b1, ndarray &b2, ndarray &R )
 {
   CentralRelativeAdapter adapter(b1, b2, R);
   return arrayFromTranslation(
     opengv::relative_pose::twopt(adapter, true, 0, 1));
 }
 
-bp::object twopt_rotationOnly( bpn::array &b1, bpn::array &b2 )
+bp::object twopt_rotationOnly( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return arrayFromRotation(
     opengv::relative_pose::twopt_rotationOnly(adapter, 0, 1));
 }
 
-bp::object rotationOnly( bpn::array &b1, bpn::array &b2 )
+bp::object rotationOnly( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return arrayFromRotation(
     opengv::relative_pose::rotationOnly(adapter));
 }
 
-bp::object fivept_nister( bpn::array &b1, bpn::array &b2 )
+bp::object fivept_nister( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromEssentials(
     opengv::relative_pose::fivept_nister(adapter));
 }
 
-bp::object fivept_kneip( bpn::array &b1, bpn::array &b2 )
+bp::object fivept_kneip( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromRotations(
     opengv::relative_pose::fivept_kneip(adapter, getNindices(5)));
 }
 
-bp::object sevenpt( bpn::array &b1, bpn::array &b2 )
+bp::object sevenpt( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromEssentials(
     opengv::relative_pose::sevenpt(adapter));
 }
 
-bp::object eightpt( bpn::array &b1, bpn::array &b2 )
+bp::object eightpt( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return arrayFromEssential(
     opengv::relative_pose::eightpt(adapter));
 }
 
-bp::object eigensolver( bpn::array &b1, bpn::array &b2, bpn::array &R )
+bp::object eigensolver( ndarray &b1, ndarray &b2, ndarray &R )
 {
   CentralRelativeAdapter adapter(b1, b2, R);
   return arrayFromRotation(
     opengv::relative_pose::eigensolver(adapter));
 }
 
-bp::object sixpt( bpn::array &b1, bpn::array &b2 )
+bp::object sixpt( ndarray &b1, ndarray &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromRotations(
     opengv::relative_pose::sixpt(adapter));
 }
 
-bp::object optimize_nonlinear( bpn::array &b1,
-                               bpn::array &b2,
-                               bpn::array &t12,
-                               bpn::array &R12 )
+bp::object optimize_nonlinear( ndarray &b1,
+                               ndarray &b2,
+                               ndarray &t12,
+                               ndarray &R12 )
 {
   CentralRelativeAdapter adapter(b1, b2, t12, R12);
   return arrayFromTransformation(
@@ -489,8 +483,8 @@ bp::object optimize_nonlinear( bpn::array &b1,
 }
 
 bp::object ransac(
-    bpn::array &b1,
-    bpn::array &b2,
+    ndarray &b1,
+    ndarray &b2,
     std::string algo_name,
     double threshold,
     int max_iterations )
@@ -523,8 +517,8 @@ bp::object ransac(
 }
 
 bp::object ransac_rotationOnly(
-    bpn::array &b1,
-    bpn::array &b2,
+    ndarray &b1,
+    ndarray &b2,
     double threshold,
     int max_iterations )
 {
@@ -553,10 +547,10 @@ bp::object ransac_rotationOnly(
 namespace triangulation
 {
 
-bp::object triangulate( bpn::array &b1,
-                        bpn::array &b2,
-                        bpn::array &t12,
-                        bpn::array &R12 )
+bp::object triangulate( ndarray &b1,
+                        ndarray &b2,
+                        ndarray &t12,
+                        ndarray &R12 )
 {
   pyopengv::relative_pose::CentralRelativeAdapter adapter(b1, b2, t12, R12);
 
@@ -569,10 +563,10 @@ bp::object triangulate( bpn::array &b1,
   return arrayFromPoints(points);
 }
 
-bp::object triangulate2( bpn::array &b1,
-                         bpn::array &b2,
-                         bpn::array &t12,
-                         bpn::array &R12 )
+bp::object triangulate2( ndarray &b1,
+                         ndarray &b2,
+                         ndarray &t12,
+                         ndarray &R12 )
 {
   pyopengv::relative_pose::CentralRelativeAdapter adapter(b1, b2, t12, R12);
 
@@ -593,7 +587,11 @@ bp::object triangulate2( bpn::array &b1,
 BOOST_PYTHON_MODULE(pyopengv) {
   using namespace boost::python;
 
+#ifdef USE_BOOST_PYTHON_NUMPY
+  boost::python::numpy::initialize();
+#else
   boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
+#endif
   numpy_import_array_wrapper();
 
   def("absolute_pose_p2p", pyopengv::absolute_pose::p2p);

--- a/python/types.hpp
+++ b/python/types.hpp
@@ -2,16 +2,20 @@
 #define __TYPES_H__
 
 #include <boost/python.hpp>
+#ifdef USE_BOOST_PYTHON_NUMPY
+#include <boost/python/numpy.hpp>
+#endif
+
 #include <vector>
 #include <iostream>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/ndarrayobject.h>
 
+
 namespace pyopengv {
 
 namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
 
 template <typename T> inline int numpy_typenum() {}
 template <> inline int numpy_typenum<bool>() { return NPY_BOOL; }
@@ -39,25 +43,65 @@ template <> inline const char *type_string<unsigned long long>() { return "uint6
 template <> inline const char *type_string<float>() { return "float32"; }
 template <> inline const char *type_string<double>() { return "float64"; }
 
+
+#ifdef USE_BOOST_PYTHON_NUMPY
+
+namespace bpn = boost::python::numpy;
+typedef bpn::ndarray ndarray;
+
 template <typename T>
-bp::object bpn_array_from_data(int nd, npy_intp *shape, const T *data) {
+bp::object bpn_array_from_data(const T *data, int shape0) {
+  bp::tuple shape = bp::make_tuple(shape0);
+  bpn::dtype dtype =  bpn::dtype::get_builtin<T>();
+  bpn::ndarray res = bpn::empty(shape, dtype);
+  std::copy(data, data + shape0, reinterpret_cast<T*>(res.get_data()));
+  return res;
+}
+
+template <typename T>
+bp::object bpn_array_from_data(const T *data, int shape0, int shape1) {
+  bp::tuple shape = bp::make_tuple(shape0, shape1);
+  bpn::dtype dtype =  bpn::dtype::get_builtin<T>();
+  bpn::ndarray res = bpn::empty(shape, dtype);
+  std::copy(data, data + shape0 * shape1, reinterpret_cast<T*>(res.get_data()));
+  return res;
+}
+
+#else
+
+namespace bpn = boost::python::numeric;
+typedef bpn::array ndarray;
+
+template <typename T>
+bp::object bpn_array_from_data(const T *data, int shape0) {
+  npy_intp shape[1] = {shape0};
   PyObject *pyarray = PyArray_SimpleNewFromData(
-      nd, shape, numpy_typenum<T>(), (void *)data);
+      1, shape, numpy_typenum<T>(), (void *)data);
   bp::handle<> handle(pyarray);
   return bpn::array(handle).copy(); // copy the object. numpy owns the copy now.
 }
 
 template <typename T>
+bp::object bpn_array_from_data(const T *data, int shape0, int shape1) {
+  npy_intp shape[2] = {shape0, shape1};
+  PyObject *pyarray = PyArray_SimpleNewFromData(
+      2, shape, numpy_typenum<T>(), (void *)data);
+  bp::handle<> handle(pyarray);
+  return bpn::array(handle).copy(); // copy the object. numpy owns the copy now.
+}
+
+#endif
+
+template <typename T>
 bp::object bpn_array_from_vector(const std::vector<T> &v) {
-  npy_intp shape[] = { v.size() };
   const T *data = v.size() ? &v[0] : NULL;
-  return bpn_array_from_data(1, shape, data);
+  return bpn_array_from_data(data, v.size());
 }
 
 template<typename T>
 class PyArrayContiguousView {
  public:
-  PyArrayContiguousView(bpn::array &array) {
+  PyArrayContiguousView(ndarray &array) {
     init((PyArrayObject *)array.ptr());
   }
 


### PR DESCRIPTION
Previously, boost-python included the `numeric` module to interface with numpy arrays.  They have removed that module from version 1.65.

Since version 1.63 there is an alternative module called boost python `numpy`.

This change makes pyopengv use the newer boost python numpy when available.

Fixes laurentkneip/opengv#50