### PR TITLE
cannot convert ‘int*’ to ‘const mwSize'

### DIFF
--- a/matlab/opengv.cpp
+++ b/matlab/opengv.cpp
@@ -680,7 +680,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::p2p(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::p2p(*absoluteAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 1;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -702,7 +702,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::p3p_kneip(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::p3p_kneip(*absoluteAdapter);
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 4;
       dims[2] = temp.size();
@@ -729,7 +729,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::p3p_gao(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::p3p_gao(*absoluteAdapter);
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 4;
       dims[2] = temp.size();
@@ -756,7 +756,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::epnp(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::epnp(*absoluteAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -775,7 +775,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 1.0 - cos(atan(sqrt(2.0)*0.5/800.0));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -808,7 +808,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 1.0 - cos(atan(sqrt(2.0)*0.5/800.0));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -840,7 +840,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 1.0 - cos(atan(sqrt(2.0)*0.5/800.0));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -875,7 +875,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::optimize_nonlinear(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::optimize_nonlinear(*absoluteAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -897,7 +897,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::gp3p(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::gp3p(*absoluteAdapter);
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 4;
       dims[2] = temp.size();
@@ -921,7 +921,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 1.0 - cos(atan(sqrt(2.0)*0.5/800.0));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -956,7 +956,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::gpnp(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::gpnp(*absoluteAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -978,7 +978,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::absolute_pose::optimize_nonlinear(*absoluteAdapter,indices);
       else
         temp = opengv::absolute_pose::optimize_nonlinear(*absoluteAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1001,7 +1001,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       else
         temp = opengv::absolute_pose::upnp(*absoluteAdapter);
       
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 4;
       dims[2] = temp.size();
@@ -1028,7 +1028,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::twopt(*relativeAdapter,false,indices);
       else
         temp = opengv::relative_pose::twopt(*relativeAdapter,false);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 1;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1050,7 +1050,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::twopt_rotationOnly(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::twopt_rotationOnly(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 3;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1072,7 +1072,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::rotationOnly(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::rotationOnly(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 3;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1105,7 +1105,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         }
         temp.push_back(essentialMatrix);
       }
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 3;
       dims[2] = temp.size();
@@ -1132,7 +1132,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::fivept_nister(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::fivept_nister(*relativeAdapter);
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 3;
       dims[2] = temp.size();
@@ -1166,7 +1166,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         mexPrintf("You must provide an indices vector\n");
         break;
       }
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 3;
       dims[2] = temp.size();
@@ -1193,7 +1193,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::sevenpt(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::sevenpt(*relativeAdapter);
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 3;
       dims[2] = temp.size();
@@ -1220,7 +1220,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::eightpt(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::eightpt(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 3;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1242,7 +1242,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::eigensolver(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::eigensolver(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 3;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1261,7 +1261,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 3;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1297,7 +1297,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       opengv::transformation_t optimizedModel;
       problem->optimizeModelCoefficients(ransac.inliers_,ransac.model_coefficients_,optimizedModel);
 
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1330,7 +1330,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1362,7 +1362,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1394,7 +1394,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1429,7 +1429,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       opengv::transformation_t temp;
       temp.block<3,3>(0,0) = ransac.model_coefficients_.rotation;
       temp.block<3,1>(0,3) = ransac.model_coefficients_.translation;
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1464,7 +1464,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::optimize_nonlinear(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::optimize_nonlinear(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1486,7 +1486,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::sixpt(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::sixpt(*relativeAdapter);
-      int dims[3];
+      mwSize dims[3];
       dims[0] = 3;
       dims[1] = 3;
       dims[2] = temp.size();
@@ -1513,7 +1513,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::seventeenpt(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::seventeenpt(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1537,7 +1537,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::ge(*relativeAdapter,indices,output);
       else
         temp = opengv::relative_pose::ge(*relativeAdapter,output);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 3;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1556,7 +1556,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1588,7 +1588,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1620,7 +1620,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 2.0*(1.0 - cos(atan(sqrt(2.0)*0.5/800.0)));
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1655,7 +1655,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::relative_pose::optimize_nonlinear(*relativeAdapter,indices);
       else
         temp = opengv::relative_pose::optimize_nonlinear(*relativeAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1677,7 +1677,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
         temp = opengv::point_cloud::threept_arun(*pointCloudAdapter,indices);
       else
         temp = opengv::point_cloud::threept_arun(*pointCloudAdapter);
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1696,7 +1696,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
       ransac.threshold_ = 0.1;
       ransac.max_iterations_ = 50;
       ransac.computeModel();
-      int dims[2];
+      mwSize dims[2];
       dims[0] = 3;
       dims[1] = 4;
       plhs[0] = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);


### PR DESCRIPTION
In order to fix these kind of errors:
   `opengv/matlab/opengv.cpp:686:69: error: cannot convert ‘int*’ to ‘const mwSize* {aka const long unsigned int*}’ for argument ‘2’ to ‘mxArray* mxCreateNumericArray_730(mwSize, const mwSize*, mxClassID, mxComplexity)’`

See this answer:
   https://stackoverflow.com/questions/43045701/switch-compiler-on-matlab-2017a-in-ubuntu-os