### PR TITLE
Seed using clocks instead of seconds

### DIFF
--- a/include/opengv/sac/implementation/MultiSampleConsensusProblem.hpp
+++ b/include/opengv/sac/implementation/MultiSampleConsensusProblem.hpp
@@ -30,6 +30,8 @@
 
 //Note: has been derived from ROS
 
+#include <ctime>
+
 template<typename M>
 opengv::sac::MultiSampleConsensusProblem<M>::MultiSampleConsensusProblem(
     bool randomSeed) :
@@ -38,7 +40,7 @@ opengv::sac::MultiSampleConsensusProblem<M>::MultiSampleConsensusProblem(
   rng_dist_.reset(new std::uniform_int_distribution<>( 0, std::numeric_limits<int>::max () ));
   // Create a random number generator object
   if (randomSeed)
-    rng_alg_.seed(static_cast<unsigned> (std::time(0)));
+    rng_alg_.seed(static_cast<unsigned>(time(0)) + static_cast<unsigned>(clock()) );
   else
     rng_alg_.seed(12345u);
 

--- a/include/opengv/sac/implementation/SampleConsensusProblem.hpp
+++ b/include/opengv/sac/implementation/SampleConsensusProblem.hpp
@@ -30,6 +30,8 @@
 
 //Note: has been derived from ROS
 
+#include <ctime>
+
 template<typename M>
 opengv::sac::SampleConsensusProblem<M>::SampleConsensusProblem(
     bool randomSeed) :
@@ -38,7 +40,7 @@ opengv::sac::SampleConsensusProblem<M>::SampleConsensusProblem(
   rng_dist_.reset(new std::uniform_int_distribution<>( 0, std::numeric_limits<int>::max() ));
   // Create a random number generator object
   if(randomSeed)
-    rng_alg_.seed(static_cast<unsigned> (std::time(0)));
+    rng_alg_.seed(static_cast<unsigned>(time(0)) + static_cast<unsigned>(clock()) );
   else
     rng_alg_.seed(12345u);
 


### PR DESCRIPTION
Seeding the random generator is currently done using time in seconds. This gives the same seed for
all executions within the same second.

Clocks change faster so that this does not happen. However, `clock()` can give similar values for different the executions of the program since it computes the time from the start of the program. So we combine both time and clock.

Does this matter at all?  Generally, not much. I hit the problem when running multiple RANSAC times with the same data as input. I expected the result to change but was getting the exact same value.
