### PR TITLE
Optional python binding with pybind11.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "python_pybind/pybind11"]
+	path = python_pybind/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ IF(BUILD_POSITION_INDEPENDENT_CODE)
   add_definitions( -fPIC )
 ENDIF()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ADD_DEFINITIONS (
+-Wall
+)
+else ()
 ADD_DEFINITIONS (
 -Wall
 -Wextra
@@ -47,6 +52,7 @@ ADD_DEFINITIONS (
 -Wno-unused-parameter
 -fno-strict-aliasing
 )
+endif ()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules/")
 find_package(Eigen REQUIRED)
@@ -336,5 +342,11 @@ install(EXPORT opengv-export DESTINATION CMake FILE opengv-config.cmake)
 
 
 if (BUILD_PYTHON)
+OPTION(BUILD_PYTHON_WITH_BOOST "Build Python extension" OFF)
+endif()
+
+if (BUILD_PYTHON_WITH_BOOST)
   add_subdirectory( python )
+else()
+  add_subdirectory( python_pybind )
 endif()

--- a/python_pybind/CMakeLists.txt
+++ b/python_pybind/CMakeLists.txt
@@ -1,0 +1,38 @@
+# cmake_minimum_required(VERSION 3.1.0)
+# project(opengv_python_pybind_standalone CXX)
+
+# set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/modules/")
+## find_package(opengv REQUIRED)
+# include( C:/tools/cmake_install_libs/opengv/CMake/opengv-config.cmake )
+
+
+set(LIBNAME pyopengv)
+
+add_subdirectory( pybind11 )
+
+find_package(PythonLibs REQUIRED)
+include_directories(${PYTHON_INCLUDE_DIRS})
+
+find_package(NumPy REQUIRED)
+include_directories(${NUMPY_INCLUDE_DIRS})
+
+add_library(${LIBNAME} MODULE pyopengv.cpp) # note the module for building libs
+target_link_libraries(${LIBNAME} opengv pybind11::module)
+
+if( MSVC )
+set_target_properties(${LIBNAME} PROPERTIES
+    SUFFIX ".pyd"
+)
+else()
+set_target_properties(${LIBNAME} PROPERTIES
+    SUFFIX ".so"
+)
+endif()
+
+set(py_ver "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+MESSAGE( STATUS "python version: " ${py_ver} )
+
+set(PYTHON_INSTALL_DIR
+    "${CMAKE_INSTALL_PREFIX}/lib/python${py_ver}")
+
+install(TARGETS ${LIBNAME} DESTINATION "${PYTHON_INSTALL_DIR}")

--- a/python_pybind/CMakeLists.txt
+++ b/python_pybind/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 
 set(LIBNAME pyopengv)
+add_definitions ( -DLIBNAME=${LIBNAME} ) # to be used in cpp file
 
 add_subdirectory( pybind11 )
 
@@ -21,10 +22,12 @@ target_link_libraries(${LIBNAME} opengv pybind11::module)
 
 if( MSVC )
 set_target_properties(${LIBNAME} PROPERTIES
+    PREFIX ""
     SUFFIX ".pyd"
 )
 else()
 set_target_properties(${LIBNAME} PROPERTIES
+    PREFIX ""
     SUFFIX ".so"
 )
 endif()

--- a/python_pybind/pyopengv.cpp
+++ b/python_pybind/pyopengv.cpp
@@ -1,0 +1,615 @@
+#include <pybind11/pybind11.h>
+#include <iostream>
+#include <vector>
+#include <opengv/absolute_pose/AbsoluteAdapterBase.hpp>
+#include <opengv/absolute_pose/methods.hpp>
+#include <opengv/relative_pose/RelativeAdapterBase.hpp>
+#include <opengv/relative_pose/methods.hpp>
+#include <opengv/sac/Ransac.hpp>
+#include <opengv/sac_problems/absolute_pose/AbsolutePoseSacProblem.hpp>
+#include <opengv/sac_problems/relative_pose/CentralRelativePoseSacProblem.hpp>
+#include <opengv/sac_problems/relative_pose/RotationOnlySacProblem.hpp>
+#include <opengv/triangulation/methods.hpp>
+
+#include "types.hpp"
+#include <numpy/ndarrayobject.h>
+
+/* Initialise numpy API and use 2/3 compatible return */
+#if (PY_VERSION_HEX < 0x03000000)
+static void numpy_import_array_wrapper() {
+  import_array();
+}
+#else
+static int numpy_import_array_wrapper() {
+  import_array();
+  return 0;
+}
+#endif
+
+
+namespace pyopengv {
+
+
+typedef PyArrayContiguousView<double> pyarray_t;
+
+
+opengv::bearingVector_t bearingVectorFromArray(
+    const pyarray_t &array,
+    size_t index )
+{
+  opengv::bearingVector_t v;
+  v[0] = array.get(index, 0);
+  v[1] = array.get(index, 1);
+  v[2] = array.get(index, 2);
+  return v;
+}
+
+opengv::point_t pointFromArray(
+    const pyarray_t &array,
+    size_t index )
+{
+  opengv::point_t p;
+  p[0] = array.get(index, 0);
+  p[1] = array.get(index, 1);
+  p[2] = array.get(index, 2);
+  return p;
+}
+
+py::object arrayFromPoints( const opengv::points_t &points )
+{
+  std::vector<double> data(points.size() * 3);
+  for (size_t i = 0; i < points.size(); ++i) {
+    data[3 * i + 0] = points[i][0];
+    data[3 * i + 1] = points[i][1];
+    data[3 * i + 2] = points[i][2];
+  }
+  return py_array_from_data(&data[0], points.size(), 3);
+}
+
+py::object arrayFromTranslation( const opengv::translation_t &t )
+{
+  return py_array_from_data(t.data(), 3);
+}
+
+py::object arrayFromRotation( const opengv::rotation_t &R )
+{
+  Eigen::Matrix<double, 3, 3, Eigen::RowMajor> R_row_major = R;
+  return py_array_from_data(R_row_major.data(), 3, 3);
+}
+
+py::list listFromRotations( const opengv::rotations_t &Rs )
+{
+  py::list retn;
+  for (size_t i = 0; i < Rs.size(); ++i) {
+    retn.append(arrayFromRotation(Rs[i]));
+  }
+  return retn;
+}
+
+py::object arrayFromEssential( const opengv::essential_t &E )
+{
+  Eigen::Matrix<double, 3, 3, Eigen::RowMajor> E_row_major = E;
+  return py_array_from_data(E_row_major.data(), 3, 3);
+}
+
+py::list listFromEssentials( const opengv::essentials_t &Es )
+{
+  py::list retn;
+  for (size_t i = 0; i < Es.size(); ++i) {
+    retn.append(arrayFromEssential(Es[i]));
+  }
+  return retn;
+}
+
+py::object arrayFromTransformation( const opengv::transformation_t &t )
+{
+  Eigen::Matrix<double, 3, 4, Eigen::RowMajor> t_row_major = t;
+  return py_array_from_data(t_row_major.data(), 3, 4);
+}
+
+py::list listFromTransformations( const opengv::transformations_t &t )
+{
+  py::list retn;
+  for (size_t i = 0; i < t.size(); ++i) {
+    retn.append(arrayFromTransformation(t[i]));
+  }
+  return retn;
+}
+
+std::vector<int> getNindices( int n )
+{
+  std::vector<int> indices;
+  for(int i = 0; i < n; i++)
+    indices.push_back(i);
+  return indices;
+}
+
+
+namespace absolute_pose {
+
+class CentralAbsoluteAdapter : public opengv::absolute_pose::AbsoluteAdapterBase
+{
+protected:
+  using AbsoluteAdapterBase::_t;
+  using AbsoluteAdapterBase::_R;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  CentralAbsoluteAdapter(
+      ndarray &bearingVectors,
+      ndarray &points )
+    : _bearingVectors(bearingVectors)
+    , _points(points)
+  {}
+
+  CentralAbsoluteAdapter(
+      ndarray &bearingVectors,
+      ndarray &points,
+      ndarray &R )
+    : _bearingVectors(bearingVectors)
+    , _points(points)
+  {
+    pyarray_t R_view(R);
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        _R(i, j) = R_view.get(i, j);
+      }
+    }
+  }
+
+  CentralAbsoluteAdapter(
+      ndarray &bearingVectors,
+      ndarray &points,
+      ndarray &t,
+      ndarray &R )
+    : _bearingVectors(bearingVectors)
+    , _points(points)
+  {
+    pyarray_t t_view(t);
+    for (int i = 0; i < 3; ++i) {
+      _t(i) = t_view.get(i);
+    }
+    pyarray_t R_view(R);
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        _R(i, j) = R_view.get(i, j);
+      }
+    }
+  }
+
+  virtual ~CentralAbsoluteAdapter() {}
+
+  //Access of correspondences
+
+  virtual opengv::bearingVector_t getBearingVector( size_t index ) const {
+    return bearingVectorFromArray(_bearingVectors, index);
+  }
+
+  virtual double getWeight( size_t index ) const {
+    return 1.0;
+  }
+
+  virtual opengv::translation_t getCamOffset( size_t index ) const {
+    return Eigen::Vector3d::Zero();
+  }
+
+  virtual opengv::rotation_t getCamRotation( size_t index ) const {
+    return opengv::rotation_t::Identity();
+  }
+
+  virtual opengv::point_t getPoint( size_t index ) const {
+    return pointFromArray(_points, index);
+  }
+
+  virtual size_t getNumberCorrespondences() const {
+    return _bearingVectors.shape(0);
+  }
+
+protected:
+  pyarray_t _bearingVectors;
+  pyarray_t _points;
+};
+
+
+
+py::object p2p( ndarray &v, ndarray &p, ndarray &R )
+{
+  CentralAbsoluteAdapter adapter(v, p, R);
+  return arrayFromTranslation(
+    opengv::absolute_pose::p2p(adapter, 0, 1));
+}
+
+py::object p3p_kneip( ndarray &v, ndarray &p )
+{
+  CentralAbsoluteAdapter adapter(v, p);
+  return listFromTransformations(
+    opengv::absolute_pose::p3p_kneip(adapter, 0, 1, 2));
+}
+
+py::object p3p_gao( ndarray &v, ndarray &p )
+{
+  CentralAbsoluteAdapter adapter(v, p);
+  return listFromTransformations(
+    opengv::absolute_pose::p3p_gao(adapter, 0, 1, 2));
+}
+
+py::object gp3p( ndarray &v, ndarray &p )
+{
+  CentralAbsoluteAdapter adapter(v, p);
+  return listFromTransformations(
+    opengv::absolute_pose::gp3p(adapter, 0, 1, 2));
+}
+
+py::object epnp( ndarray &v, ndarray &p )
+{
+  CentralAbsoluteAdapter adapter(v, p);
+  return arrayFromTransformation(
+    opengv::absolute_pose::epnp(adapter));
+}
+
+py::object gpnp( ndarray &v, ndarray &p )
+{
+  CentralAbsoluteAdapter adapter(v, p);
+  return arrayFromTransformation(
+    opengv::absolute_pose::gpnp(adapter));
+}
+
+py::object upnp( ndarray &v, ndarray &p )
+{
+  CentralAbsoluteAdapter adapter(v, p);
+  return listFromTransformations(
+    opengv::absolute_pose::upnp(adapter));
+}
+
+py::object optimize_nonlinear( ndarray &v,
+                               ndarray &p,
+                               ndarray &t,
+                               ndarray &R )
+{
+  CentralAbsoluteAdapter adapter(v, p, t, R);
+  return arrayFromTransformation(
+    opengv::absolute_pose::optimize_nonlinear(adapter));
+}
+
+py::object ransac(
+    ndarray &v,
+    ndarray &p,
+    std::string algo_name,
+    double threshold,
+    int max_iterations )
+{
+  using namespace opengv::sac_problems::absolute_pose;
+
+  CentralAbsoluteAdapter adapter(v, p);
+
+  // Create a ransac problem
+  AbsolutePoseSacProblem::algorithm_t algorithm = AbsolutePoseSacProblem::KNEIP;
+  if (algo_name == "TWOPT") algorithm = AbsolutePoseSacProblem::TWOPT;
+  else if (algo_name == "KNEIP") algorithm = AbsolutePoseSacProblem::KNEIP;
+  else if (algo_name == "GAO") algorithm = AbsolutePoseSacProblem::GAO;
+  else if (algo_name == "EPNP") algorithm = AbsolutePoseSacProblem::EPNP;
+  else if (algo_name == "GP3P") algorithm = AbsolutePoseSacProblem::GP3P;
+
+  std::shared_ptr<AbsolutePoseSacProblem>
+      absposeproblem_ptr(
+        new AbsolutePoseSacProblem(adapter, algorithm));
+
+  // Create a ransac solver for the problem
+  opengv::sac::Ransac<AbsolutePoseSacProblem> ransac;
+
+  ransac.sac_model_ = absposeproblem_ptr;
+  ransac.threshold_ = threshold;
+  ransac.max_iterations_ = max_iterations;
+
+  // Solve
+  ransac.computeModel();
+  return arrayFromTransformation(ransac.model_coefficients_);
+}
+
+
+
+} // namespace absolute_pose
+
+
+namespace relative_pose
+{
+
+class CentralRelativeAdapter : public opengv::relative_pose::RelativeAdapterBase
+{
+protected:
+  using RelativeAdapterBase::_t12;
+  using RelativeAdapterBase::_R12;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  CentralRelativeAdapter(
+      ndarray &bearingVectors1,
+      ndarray &bearingVectors2 )
+    : _bearingVectors1(bearingVectors1)
+    , _bearingVectors2(bearingVectors2)
+  {}
+
+  CentralRelativeAdapter(
+      ndarray &bearingVectors1,
+      ndarray &bearingVectors2,
+      ndarray &R12 )
+    : _bearingVectors1(bearingVectors1)
+    , _bearingVectors2(bearingVectors2)
+  {
+    pyarray_t R12_view(R12);
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        _R12(i, j) = R12_view.get(i, j);
+      }
+    }
+  }
+
+  CentralRelativeAdapter(
+      ndarray &bearingVectors1,
+      ndarray &bearingVectors2,
+      ndarray &t12,
+      ndarray &R12 )
+    : _bearingVectors1(bearingVectors1)
+    , _bearingVectors2(bearingVectors2)
+  {
+    pyarray_t t12_view(t12);
+    for (int i = 0; i < 3; ++i) {
+      _t12(i) = t12_view.get(i);
+    }
+    pyarray_t R12_view(R12);
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        _R12(i, j) = R12_view.get(i, j);
+      }
+    }
+  }
+
+  virtual ~CentralRelativeAdapter() {}
+
+  virtual opengv::bearingVector_t getBearingVector1( size_t index ) const {
+    return bearingVectorFromArray(_bearingVectors1, index);
+  }
+
+  virtual opengv::bearingVector_t getBearingVector2( size_t index ) const {
+    return bearingVectorFromArray(_bearingVectors2, index);
+  }
+
+  virtual double getWeight( size_t index ) const {
+    return 1.0;
+  }
+
+  virtual opengv::translation_t getCamOffset1( size_t index ) const {
+    return Eigen::Vector3d::Zero();
+  }
+
+  virtual opengv::rotation_t getCamRotation1( size_t index ) const {
+    return opengv::rotation_t::Identity();
+  }
+
+  virtual opengv::translation_t getCamOffset2( size_t index ) const {
+    return Eigen::Vector3d::Zero();
+  }
+
+  virtual opengv::rotation_t getCamRotation2( size_t index ) const {
+    return opengv::rotation_t::Identity();
+  }
+
+  virtual size_t getNumberCorrespondences() const {
+    return _bearingVectors1.shape(0);
+  }
+
+protected:
+  pyarray_t _bearingVectors1;
+  pyarray_t _bearingVectors2;
+};
+
+
+py::object twopt( ndarray &b1, ndarray &b2, ndarray &R )
+{
+  CentralRelativeAdapter adapter(b1, b2, R);
+  return arrayFromTranslation(
+    opengv::relative_pose::twopt(adapter, true, 0, 1));
+}
+
+py::object twopt_rotationOnly( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return arrayFromRotation(
+    opengv::relative_pose::twopt_rotationOnly(adapter, 0, 1));
+}
+
+py::object rotationOnly( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return arrayFromRotation(
+    opengv::relative_pose::rotationOnly(adapter));
+}
+
+py::object fivept_nister( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return listFromEssentials(
+    opengv::relative_pose::fivept_nister(adapter));
+}
+
+py::object fivept_kneip( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return listFromRotations(
+    opengv::relative_pose::fivept_kneip(adapter, getNindices(5)));
+}
+
+py::object sevenpt( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return listFromEssentials(
+    opengv::relative_pose::sevenpt(adapter));
+}
+
+py::object eightpt( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return arrayFromEssential(
+    opengv::relative_pose::eightpt(adapter));
+}
+
+py::object eigensolver( ndarray &b1, ndarray &b2, ndarray &R )
+{
+  CentralRelativeAdapter adapter(b1, b2, R);
+  return arrayFromRotation(
+    opengv::relative_pose::eigensolver(adapter));
+}
+
+py::object sixpt( ndarray &b1, ndarray &b2 )
+{
+  CentralRelativeAdapter adapter(b1, b2);
+  return listFromRotations(
+    opengv::relative_pose::sixpt(adapter));
+}
+
+py::object optimize_nonlinear( ndarray &b1,
+                               ndarray &b2,
+                               ndarray &t12,
+                               ndarray &R12 )
+{
+  CentralRelativeAdapter adapter(b1, b2, t12, R12);
+  return arrayFromTransformation(
+    opengv::relative_pose::optimize_nonlinear(adapter));
+}
+
+py::object ransac(
+    ndarray &b1,
+    ndarray &b2,
+    std::string algo_name,
+    double threshold,
+    int max_iterations )
+{
+  using namespace opengv::sac_problems::relative_pose;
+
+  CentralRelativeAdapter adapter(b1, b2);
+
+  // Create a ransac problem
+  CentralRelativePoseSacProblem::algorithm_t algorithm = CentralRelativePoseSacProblem::NISTER;
+  if (algo_name == "STEWENIUS") algorithm = CentralRelativePoseSacProblem::STEWENIUS;
+  else if (algo_name == "NISTER") algorithm = CentralRelativePoseSacProblem::NISTER;
+  else if (algo_name == "SEVENPT") algorithm = CentralRelativePoseSacProblem::SEVENPT;
+  else if (algo_name == "EIGHTPT") algorithm = CentralRelativePoseSacProblem::EIGHTPT;
+
+  std::shared_ptr<CentralRelativePoseSacProblem>
+      relposeproblem_ptr(
+        new CentralRelativePoseSacProblem(adapter, algorithm));
+
+  // Create a ransac solver for the problem
+  opengv::sac::Ransac<CentralRelativePoseSacProblem> ransac;
+
+  ransac.sac_model_ = relposeproblem_ptr;
+  ransac.threshold_ = threshold;
+  ransac.max_iterations_ = max_iterations;
+
+  // Solve
+  ransac.computeModel();
+  return arrayFromTransformation(ransac.model_coefficients_);
+}
+
+py::object ransac_rotationOnly(
+    ndarray &b1,
+    ndarray &b2,
+    double threshold,
+    int max_iterations )
+{
+  using namespace opengv::sac_problems::relative_pose;
+
+  CentralRelativeAdapter adapter(b1, b2);
+
+  std::shared_ptr<RotationOnlySacProblem>
+      relposeproblem_ptr(
+        new RotationOnlySacProblem(adapter));
+
+  // Create a ransac solver for the problem
+  opengv::sac::Ransac<RotationOnlySacProblem> ransac;
+
+  ransac.sac_model_ = relposeproblem_ptr;
+  ransac.threshold_ = threshold;
+  ransac.max_iterations_ = max_iterations;
+
+  // Solve
+  ransac.computeModel();
+  return arrayFromRotation(ransac.model_coefficients_);
+}
+
+} // namespace relative_pose
+
+namespace triangulation
+{
+
+py::object triangulate( ndarray &b1,
+                        ndarray &b2,
+                        ndarray &t12,
+                        ndarray &R12 )
+{
+  pyopengv::relative_pose::CentralRelativeAdapter adapter(b1, b2, t12, R12);
+
+  opengv::points_t points;
+  for (size_t i = 0; i < adapter.getNumberCorrespondences(); ++i)
+  {
+    opengv::point_t p = opengv::triangulation::triangulate(adapter, i);
+    points.push_back(p);
+  }
+  return arrayFromPoints(points);
+}
+
+py::object triangulate2( ndarray &b1,
+                         ndarray &b2,
+                         ndarray &t12,
+                         ndarray &R12 )
+{
+  pyopengv::relative_pose::CentralRelativeAdapter adapter(b1, b2, t12, R12);
+
+  opengv::points_t points;
+  for (size_t i = 0; i < adapter.getNumberCorrespondences(); ++i)
+  {
+    opengv::point_t p = opengv::triangulation::triangulate2(adapter, i);
+    points.push_back(p);
+  }
+  return arrayFromPoints(points);
+}
+
+
+} // namespace triangulation
+
+} // namespace pyopengv
+
+
+PYBIND11_MODULE ( pyopengv_pybind, m ) {
+    namespace py = pybind11;
+
+    numpy_import_array_wrapper ();
+
+    m.def ( "absolute_pose_p2p", pyopengv::absolute_pose::p2p );
+    m.def ( "absolute_pose_p3p_kneip", pyopengv::absolute_pose::p3p_kneip );
+    m.def ( "absolute_pose_p3p_gao", pyopengv::absolute_pose::p3p_gao );
+    m.def ( "absolute_pose_gp3p", pyopengv::absolute_pose::gp3p );
+    m.def ( "absolute_pose_epnp", pyopengv::absolute_pose::epnp );
+    m.def ( "absolute_pose_gpnp", pyopengv::absolute_pose::gpnp );
+    m.def ( "absolute_pose_upnp", pyopengv::absolute_pose::upnp );
+    m.def ( "absolute_pose_optimize_nonlinear", pyopengv::absolute_pose::optimize_nonlinear );
+    m.def ( "absolute_pose_ransac", pyopengv::absolute_pose::ransac );
+
+    m.def ( "relative_pose_twopt", pyopengv::relative_pose::twopt );
+    m.def ( "relative_pose_twopt_rotation_only", pyopengv::relative_pose::twopt_rotationOnly );
+    m.def ( "relative_pose_rotation_only", pyopengv::relative_pose::rotationOnly );
+    m.def ( "relative_pose_fivept_nister", pyopengv::relative_pose::fivept_nister );
+    m.def ( "relative_pose_fivept_kneip", pyopengv::relative_pose::fivept_kneip );
+    m.def ( "relative_pose_sevenpt", pyopengv::relative_pose::sevenpt );
+    m.def ( "relative_pose_eightpt", pyopengv::relative_pose::eightpt );
+    m.def ( "relative_pose_eigensolver", pyopengv::relative_pose::eigensolver );
+    m.def ( "relative_pose_sixpt", pyopengv::relative_pose::sixpt );
+    m.def ( "relative_pose_optimize_nonlinear", pyopengv::relative_pose::optimize_nonlinear );
+    m.def ( "relative_pose_ransac", pyopengv::relative_pose::ransac );
+    m.def ( "relative_pose_ransac_rotation_only", pyopengv::relative_pose::ransac_rotationOnly );
+
+    m.def ( "triangulation_triangulate", pyopengv::triangulation::triangulate );
+    m.def ( "triangulation_triangulate2", pyopengv::triangulation::triangulate2 );
+}

--- a/python_pybind/pyopengv.cpp
+++ b/python_pybind/pyopengv.cpp
@@ -581,8 +581,13 @@ py::object triangulate2( ndarray &b1,
 
 } // namespace pyopengv
 
+#ifdef LIBNAME
+#define libname LIBNAME
+#else
+#define libname pyopengv
+#endif
 
-PYBIND11_MODULE ( pyopengv_pybind, m ) {
+PYBIND11_MODULE ( libname, m ) {
     namespace py = pybind11;
 
     numpy_import_array_wrapper ();

--- a/python_pybind/tests.py
+++ b/python_pybind/tests.py
@@ -1,9 +1,4 @@
-try:
-    import pyopengv
-except Exception as e:
-    import pyopengv_pybind as pyopengv
-
-
+import pyopengv
 import numpy as np
 
 def normalized(x):
@@ -159,7 +154,7 @@ class RelativePoseDataset:
 
 
 def test_relative_pose():
-    print("Testing relative pose")
+    print "Testing relative pose"
 
     d = RelativePoseDataset(10, 0.0, 0.0)
 
@@ -174,10 +169,6 @@ def test_relative_pose():
     t_perturbed, R_perturbed = getPerturbedPose( d.position, d.rotation, 0.1)
     nonlinear_transformation = pyopengv.relative_pose_optimize_nonlinear(d.bearing_vectors1, d.bearing_vectors2, t_perturbed, R_perturbed)
 
-
-    print(d.position)
-    print(twopt_translation)
-
     assert proportional(d.position, twopt_translation)
     assert matrix_in_list(d.essential, fivept_nister_essentials)
     assert matrix_in_list(d.rotation, fivept_kneip_rotations)
@@ -186,11 +177,11 @@ def test_relative_pose():
     assert proportional(d.rotation, eigensolver_rotation)
     assert same_transformation(d.position, d.rotation, nonlinear_transformation)
 
-    print("Done testing relative pose")
+    print "Done testing relative pose"
 
 
 def test_relative_pose_ransac():
-    print("Testing relative pose ransac")
+    print "Testing relative pose ransac"
 
     d = RelativePoseDataset(100, 0.0, 0.3)
 
@@ -199,11 +190,11 @@ def test_relative_pose_ransac():
 
     assert same_transformation(d.position, d.rotation, ransac_transformation)
 
-    print("Done testing relative pose ransac")
+    print "Done testing relative pose ransac"
 
 
 def test_relative_pose_ransac_rotation_only():
-    print("Testing relative pose ransac rotation only")
+    print "Testing relative pose ransac rotation only"
 
     d = RelativePoseDataset(100, 0.0, 0.3, rotation_only=True)
 
@@ -212,11 +203,11 @@ def test_relative_pose_ransac_rotation_only():
 
     assert proportional(d.rotation, ransac_rotation)
 
-    print("Done testing relative pose ransac rotation only")
+    print "Done testing relative pose ransac rotation only"
 
 
 def test_triangulation():
-    print("Testing triangulation")
+    print "Testing triangulation"
 
     d = RelativePoseDataset(10, 0.0, 0.0)
 
@@ -230,13 +221,11 @@ def test_triangulation():
 
     assert np.allclose(d.points, points2)
 
-    print("Done testing triangulation")
+    print "Done testing triangulation"
 
 
 if __name__ == "__main__":
     test_relative_pose()
-    """
     test_relative_pose_ransac()
     test_relative_pose_ransac_rotation_only()
     test_triangulation()
-    """

--- a/python_pybind/tests.py
+++ b/python_pybind/tests.py
@@ -1,0 +1,242 @@
+try:
+    import pyopengv
+except Exception as e:
+    import pyopengv_pybind as pyopengv
+
+
+import numpy as np
+
+def normalized(x):
+    return x / np.linalg.norm(x)
+
+def generateRandomPoint( maximumDepth, minimumDepth ):
+    cleanPoint = np.random.uniform(-1.0, 1.0, 3)
+    direction = normalized(cleanPoint)
+    return (maximumDepth - minimumDepth) * cleanPoint + minimumDepth * direction
+
+
+def generateRandomTranslation( maximumParallax ):
+    return np.random.uniform(-maximumParallax, maximumParallax, 3)
+
+
+def generateRandomRotation( maxAngle ):
+    rpy = np.random.uniform(-maxAngle, maxAngle, 3)
+
+    R1 = np.array([[1.0,  0.0,  0.0],
+                   [0.0,  np.cos(rpy[0]), -np.sin(rpy[0])],
+                   [0.0,  np.sin(rpy[0]),  np.cos(rpy[0])]])
+
+    R2 = np.array([[ np.cos(rpy[1]),  0.0,  np.sin(rpy[1])],
+                   [0.0,  1.0,  0.0],
+                   [-np.sin(rpy[1]),  0.0,  np.cos(rpy[1])]])
+
+    R3 = np.array([[np.cos(rpy[2]), -np.sin(rpy[2]),  0.0],
+                   [np.sin(rpy[2]),  np.cos(rpy[2]),  0.0],
+                   [0.0,  0.0,  1.0]])
+
+    return R3.dot(R2.dot(R1))
+
+
+def addNoise( noiseLevel, cleanPoint ):
+    noisyPoint = cleanPoint + np.random.uniform(-noiseLevel, noiseLevel, 3)
+    return normalized(noisyPoint)
+
+
+def extractRelativePose(position1, position2, rotation1, rotation2):
+    relativeRotation = rotation1.T.dot(rotation2)
+    relativePosition = rotation1.T.dot(position2 - position1)
+    return relativePosition, relativeRotation
+
+
+def essentialMatrix(position, rotation):
+  # E transforms vectors from vp 2 to 1: x_1^T * E * x_2 = 0
+  # and E = (t)_skew*R
+  t_skew = np.zeros((3, 3))
+  t_skew[0,1] = -position[2]
+  t_skew[0,2] = position[1]
+  t_skew[1,0] = position[2]
+  t_skew[1,2] = -position[0]
+  t_skew[2,0] = -position[1]
+  t_skew[2,1] = position[0]
+
+  E = t_skew.dot(rotation)
+  return normalized(E)
+
+
+def getPerturbedPose(position, rotation, amplitude):
+    dp = generateRandomTranslation(amplitude)
+    dR = generateRandomRotation(amplitude)
+    return position + dp, rotation.dot(dR)
+
+
+def proportional(x, y, tol=1e-2):
+    xn = normalized(x)
+    yn = normalized(y)
+    return (np.allclose(xn, yn, rtol=1e20, atol=tol) or
+            np.allclose(xn, -yn, rtol=1e20, atol=tol))
+
+
+def matrix_in_list(a, l):
+    for b in l:
+        if proportional(a, b):
+            return True
+    return False
+
+
+def same_transformation(position, rotation, transformation):
+    R = transformation[:, :3]
+    t = transformation[:, 3]
+    return proportional(position, t) and proportional(rotation, R)
+
+
+
+class RelativePoseDataset:
+    def __init__(self, num_points, noise, outlier_fraction, rotation_only=False):
+        # generate a random pose for viewpoint 1
+        position1 = np.zeros(3)
+        rotation1 = np.eye(3)
+
+        # generate a random pose for viewpoint 2
+        if rotation_only:
+            position2 = np.zeros(3)
+        else:
+            position2 = generateRandomTranslation(2.0)
+        rotation2 = generateRandomRotation(0.5)
+
+        # derive correspondences based on random point-cloud
+        self.generateCorrespondences(
+            position1, rotation1, position2, rotation2,
+            num_points, noise, outlier_fraction)
+
+        # Extract the relative pose
+        self.position, self.rotation = extractRelativePose(
+            position1, position2, rotation1, rotation2)
+        if not rotation_only:
+            self.essential = essentialMatrix(self.position, self.rotation)
+
+
+    def generateCorrespondences(self,
+                                position1, rotation1,
+                                position2, rotation2,
+                                num_points,
+                                noise, outlier_fraction):
+        min_depth = 4
+        max_depth = 8
+
+        # initialize point-cloud
+        self.points = np.empty((num_points, 3))
+        for i in range(num_points):
+            self.points[i] = generateRandomPoint(max_depth, min_depth)
+
+        self.bearing_vectors1 = np.empty((num_points, 3))
+        self.bearing_vectors2 = np.empty((num_points, 3))
+        for i in range(num_points):
+            # get the point in viewpoint 1
+            body_point1 = rotation1.T.dot(self.points[i] - position1)
+
+            # get the point in viewpoint 2
+            body_point2 = rotation2.T.dot(self.points[i] - position2)
+
+            self.bearing_vectors1[i] = normalized(body_point1)
+            self.bearing_vectors2[i] = normalized(body_point2)
+
+            # add noise
+            if noise > 0.0:
+                self.bearing_vectors1[i] = addNoise(noise, self.bearing_vectors1[i])
+                self.bearing_vectors2[i] = addNoise(noise, self.bearing_vectors2[i])
+
+        # add outliers
+        num_outliers = int(outlier_fraction * num_points)
+        for i in range(num_outliers):
+            # create random point
+            p = generateRandomPoint(max_depth, min_depth)
+
+            # project this point into viewpoint 2
+            body_point = rotation2.T.dot(p - position2)
+
+            # normalize the bearing vector
+            self.bearing_vectors2[i] = normalized(body_point)
+
+
+def test_relative_pose():
+    print("Testing relative pose")
+
+    d = RelativePoseDataset(10, 0.0, 0.0)
+
+    # running experiments
+    twopt_translation = pyopengv.relative_pose_twopt(d.bearing_vectors1, d.bearing_vectors2, d.rotation)
+    fivept_nister_essentials = pyopengv.relative_pose_fivept_nister(d.bearing_vectors1, d.bearing_vectors2)
+    fivept_kneip_rotations = pyopengv.relative_pose_fivept_kneip(d.bearing_vectors1, d.bearing_vectors2)
+    sevenpt_essentials = pyopengv.relative_pose_sevenpt(d.bearing_vectors1, d.bearing_vectors2)
+    eightpt_essential = pyopengv.relative_pose_eightpt(d.bearing_vectors1, d.bearing_vectors2)
+    t_perturbed, R_perturbed = getPerturbedPose( d.position, d.rotation, 0.01)
+    eigensolver_rotation = pyopengv.relative_pose_eigensolver(d.bearing_vectors1, d.bearing_vectors2, R_perturbed)
+    t_perturbed, R_perturbed = getPerturbedPose( d.position, d.rotation, 0.1)
+    nonlinear_transformation = pyopengv.relative_pose_optimize_nonlinear(d.bearing_vectors1, d.bearing_vectors2, t_perturbed, R_perturbed)
+
+
+    print(d.position)
+    print(twopt_translation)
+
+    assert proportional(d.position, twopt_translation)
+    assert matrix_in_list(d.essential, fivept_nister_essentials)
+    assert matrix_in_list(d.rotation, fivept_kneip_rotations)
+    assert matrix_in_list(d.essential, sevenpt_essentials)
+    assert proportional(d.essential, eightpt_essential)
+    assert proportional(d.rotation, eigensolver_rotation)
+    assert same_transformation(d.position, d.rotation, nonlinear_transformation)
+
+    print("Done testing relative pose")
+
+
+def test_relative_pose_ransac():
+    print("Testing relative pose ransac")
+
+    d = RelativePoseDataset(100, 0.0, 0.3)
+
+    ransac_transformation = pyopengv.relative_pose_ransac(
+        d.bearing_vectors1, d.bearing_vectors2, "NISTER", 0.01, 1000)
+
+    assert same_transformation(d.position, d.rotation, ransac_transformation)
+
+    print("Done testing relative pose ransac")
+
+
+def test_relative_pose_ransac_rotation_only():
+    print("Testing relative pose ransac rotation only")
+
+    d = RelativePoseDataset(100, 0.0, 0.3, rotation_only=True)
+
+    ransac_rotation = pyopengv.relative_pose_ransac_rotation_only(
+        d.bearing_vectors1, d.bearing_vectors2, 0.01, 1000)
+
+    assert proportional(d.rotation, ransac_rotation)
+
+    print("Done testing relative pose ransac rotation only")
+
+
+def test_triangulation():
+    print("Testing triangulation")
+
+    d = RelativePoseDataset(10, 0.0, 0.0)
+
+    points1 = pyopengv.triangulation_triangulate(
+        d.bearing_vectors1, d.bearing_vectors2, d.position, d.rotation)
+
+    assert np.allclose(d.points, points1)
+
+    points2 = pyopengv.triangulation_triangulate2(
+        d.bearing_vectors1, d.bearing_vectors2, d.position, d.rotation)
+
+    assert np.allclose(d.points, points2)
+
+    print("Done testing triangulation")
+
+
+if __name__ == "__main__":
+    test_relative_pose()
+    """
+    test_relative_pose_ransac()
+    test_relative_pose_ransac_rotation_only()
+    test_triangulation()
+    """

--- a/python_pybind/tests.py
+++ b/python_pybind/tests.py
@@ -154,7 +154,7 @@ class RelativePoseDataset:
 
 
 def test_relative_pose():
-    print "Testing relative pose"
+    print ("Testing relative pose")
 
     d = RelativePoseDataset(10, 0.0, 0.0)
 
@@ -177,11 +177,11 @@ def test_relative_pose():
     assert proportional(d.rotation, eigensolver_rotation)
     assert same_transformation(d.position, d.rotation, nonlinear_transformation)
 
-    print "Done testing relative pose"
+    print ("Done testing relative pose")
 
 
 def test_relative_pose_ransac():
-    print "Testing relative pose ransac"
+    print ("Testing relative pose ransac")
 
     d = RelativePoseDataset(100, 0.0, 0.3)
 
@@ -190,11 +190,11 @@ def test_relative_pose_ransac():
 
     assert same_transformation(d.position, d.rotation, ransac_transformation)
 
-    print "Done testing relative pose ransac"
+    print ("Done testing relative pose ransac")
 
 
 def test_relative_pose_ransac_rotation_only():
-    print "Testing relative pose ransac rotation only"
+    print ("Testing relative pose ransac rotation only")
 
     d = RelativePoseDataset(100, 0.0, 0.3, rotation_only=True)
 
@@ -203,11 +203,11 @@ def test_relative_pose_ransac_rotation_only():
 
     assert proportional(d.rotation, ransac_rotation)
 
-    print "Done testing relative pose ransac rotation only"
+    print ("Done testing relative pose ransac rotation only")
 
 
 def test_triangulation():
-    print "Testing triangulation"
+    print ("Testing triangulation")
 
     d = RelativePoseDataset(10, 0.0, 0.0)
 
@@ -221,7 +221,7 @@ def test_triangulation():
 
     assert np.allclose(d.points, points2)
 
-    print "Done testing triangulation"
+    print ("Done testing triangulation")
 
 
 if __name__ == "__main__":

--- a/python_pybind/types.hpp
+++ b/python_pybind/types.hpp
@@ -1,0 +1,124 @@
+#ifndef __TYPES_H__
+#define __TYPES_H__
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h> // use pybind numpy
+
+#include <vector>
+#include <iostream>
+
+#include <numpy/ndarrayobject.h>
+
+namespace pyopengv {
+
+namespace py = pybind11;
+typedef py::array ndarray;
+
+template <typename T> inline int numpy_typenum() {}
+template <> inline int numpy_typenum<bool>() { return NPY_BOOL; }
+template <> inline int numpy_typenum<char>() { return NPY_INT8; }
+template <> inline int numpy_typenum<short>() { return NPY_INT16; }
+template <> inline int numpy_typenum<int>() { return NPY_INT32; }
+template <> inline int numpy_typenum<long long>() { return NPY_INT64; }
+template <> inline int numpy_typenum<unsigned char>() { return NPY_UINT8; }
+template <> inline int numpy_typenum<unsigned short>() { return NPY_UINT16; }
+template <> inline int numpy_typenum<unsigned int>() { return NPY_UINT32; }
+template <> inline int numpy_typenum<unsigned long long>() { return NPY_UINT64; }
+template <> inline int numpy_typenum<float>() { return NPY_FLOAT32; }
+template <> inline int numpy_typenum<double>() { return NPY_FLOAT64; }
+
+template <typename T> inline const char *type_string() {}
+template <> inline const char *type_string<bool>() { return "bool"; }
+template <> inline const char *type_string<char>() { return "int8"; }
+template <> inline const char *type_string<short>() { return "int16"; }
+template <> inline const char *type_string<int>() { return "int32"; }
+template <> inline const char *type_string<long long>() { return "int64"; }
+template <> inline const char *type_string<unsigned char>() { return "uint8"; }
+template <> inline const char *type_string<unsigned short>() { return "uint16"; }
+template <> inline const char *type_string<unsigned int>() { return "uint32"; }
+template <> inline const char *type_string<unsigned long long>() { return "uint64"; }
+template <> inline const char *type_string<float>() { return "float32"; }
+template <> inline const char *type_string<double>() { return "float64"; }
+
+template <typename T>
+py::object py_array_from_data ( const T *data, int shape0 )
+{
+    // explicit array ( ssize_t count, const T *ptr, handle base = handle () ) : array ( { count }, {}, ptr, base ) { }
+    return py::array ( shape0, data );
+
+}
+
+template <typename T>
+py::object py_array_from_data ( const T *data, int shape0, int shape1 ) {
+    std::vector<int> shape = { shape0, shape1 };
+    // array(ShapeContainer shape, const T *ptr, handle base = handle())
+    return py::array ( shape, data );
+}
+
+
+template <typename T>
+py::object py_array_from_vector(const std::vector<T> &v) {
+  const T *data = v.size() ? &v[0] : NULL;
+  return py_array_from_data(data, v.size());
+}
+
+template<typename T>
+class PyArrayContiguousView {
+ public:
+  PyArrayContiguousView(ndarray &array) {
+    init((PyArrayObject *)array.ptr());
+  }
+
+  PyArrayContiguousView(py::object &object) {
+    init((PyArrayObject *)object.ptr());
+  }
+
+  PyArrayContiguousView(PyArrayObject *object) {
+    init(object);
+  }
+
+  ~PyArrayContiguousView() {
+    if (contiguous_) Py_DECREF(contiguous_);
+  }
+
+  const T *data() const {
+    return (T *)PyArray_DATA(contiguous_);
+  }
+
+  int ndim() const {
+    return PyArray_NDIM(contiguous_);
+  }
+
+  int shape(int dim) const {
+    return PyArray_DIMS(contiguous_)[dim];
+  }
+
+  bool valid() const {
+    return contiguous_ != NULL;
+  }
+
+  T get(size_t i) const {
+    return data()[i];
+  }
+
+  T get(size_t i, size_t j) const {
+    return data()[i * shape(1) + j];
+  }
+
+ private:
+  void init(PyArrayObject *object) {
+    int type = PyArray_DESCR(object)->type_num;
+    if (type != numpy_typenum<T>()) {
+      std::cerr << "Error in PyArrayContiguousView: expected array of type " << type_string<T>() << std::endl;
+      contiguous_ = NULL;
+    } else {
+      contiguous_ = (PyArrayObject *)PyArray_ContiguousFromAny((PyObject *)object, numpy_typenum<T>(), 0, 0);
+    }
+  };
+
+  PyArrayObject *contiguous_;
+};
+
+}
+
+#endif // __TYPES_H__


### PR DESCRIPTION
Propose using pybind11 for the python binding instead of the boost.python. 

Pros:

* boost.python is really hard to build on windows (and maybe others) platform and especially when we want to have python bindings for various python versions, what's more, it is really large.
* With pybind11, the grammar is almost very the same as boost.python but much more lightweight, we can even embed it into the source code (as shown in this PR)
* we get **python2/python3** support seamlessly and no extra effort
* we can potentially publish opengv as standalone library on **pip or conda**

This PR can be reshaped since:

* There are both boost.python and pybind11 (in python_pybind folder) at present to be chosen by the user, maybe one is enough (you know, I mean the pybind11 one :) )
* What I did is almost replace `bp` and `bpn` with `py`, maybe there can be more advanced usage of pybind11
* The test is just passing the `test.py` in python folder, more tests are better

Anyway, hope this can be helpful.