### PR TITLE
Fixing opengv::math::Bracket::dividable to prevent infinite loops with recursive bisections.

### DIFF
--- a/src/math/Sturm.cpp
+++ b/src/math/Sturm.cpp
@@ -74,6 +74,9 @@ opengv::math::Bracket::dividable( double eps ) const
     return false;
   if( numberRoots() == 0 )
     return false;
+  double center = (_upperBound + _lowerBound) / 2.0;
+  if( center == _upperBound || center == _lowerBound)
+    return false;
   return true;
 }
 


### PR DESCRIPTION
The proposed fix ensures that the method returns false if the 
interval is too small to be divided due to finite double precision.