### PR TITLE
Enable find_package in build directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ configure_package_config_file(
     "${project_config}"
     INSTALL_DESTINATION "${config_install_dir}")
 
+# Export '<PROJECT-NAME>Targets.cmake' to build dir (to find package in build dir without install)
+export(TARGETS opengv FILE "${CMAKE_CURRENT_BINARY_DIR}/${targets_export_name}.cmake")
+
 # Targets:
 install(TARGETS opengv
         EXPORT "${targets_export_name}"


### PR DESCRIPTION
- export the missing opengvTargets.cmake to the build directory
- see https://github.com/laurentkneip/opengv/pull/45#issuecomment-430534282

cc @simogasp 