### PR TITLE
Use pybind11 instead of boost python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 lib
 build
 *.mexa64
+*.pyc
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "python/pybind11"]
+	path = python/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/doc/addons/01_installation.dox
+++ b/doc/addons/01_installation.dox
@@ -202,7 +202,20 @@ mex -I../include -I../EigenIncludePath -L../build/lib -lopengv opengv.cpp -cxx
  *
  * \section sec_installation_7 Installing the python wrappers
  *
- * The compliation of the Python wrappers can be enabled by setting the option BUILD_PYTHON to ON. Note that the python wrappers depend additionally on boost, and that the wrapper currently only allows access to the central methods.
+ * The Python wrappers depend on the pybind11 library, which is included as a git submodule.
+ * To get it, run
+ \verbatim
+git submodule update --init --recursive
+\endverbatim
+ * With that done, the compliation of the Python wrappers can be enabled by setting the option BUILD_PYTHON to ON.
+ * The especific version of Python to target can be set using the option PYBIND11_PYTHON_VERSION.
+ * For example,
+\verbatim
+cmake ../opengv
+  -DBUILD_PYTHON=ON
+  -DPYBIND11_PYTHON_VERSION=3.6
+\endverbatim
+ * Note that the python wrappers currently only allow access to the central methods.
  *
  * \section sec_installation_8 Using the OpenGV inside your cmake c++ project
  *

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,38 +1,15 @@
 
-find_package(Boost COMPONENTS python-py35 REQUIRED)
-include_directories(${Boost_INCLUDE_DIRS})
+add_subdirectory(pybind11)
 
-set(Python_ADDITIONAL_VERSIONS "3.5")
-find_package(PythonLibs 3 REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
-find_package(NumPy REQUIRED)
-include_directories(${NUMPY_INCLUDE_DIRS})
 
-add_library( pyopengv SHARED pyopengv.cpp )
-target_link_libraries(pyopengv opengv)
+pybind11_add_module(pyopengv pyopengv.cpp)
+target_link_libraries(pyopengv PRIVATE opengv)
 
-set_target_properties(pyopengv PROPERTIES
-                    CXX_STANDARD 11
-                    CXX_STANDARD_REQUIRED ON
-                    SOVERSION ${PROJECT_VERSION}
-                    VERSION ${PROJECT_VERSION}
-                    PREFIX ""
-                    SUFFIX ".so")
-if(APPLE)
-    set_target_properties(pyopengv PROPERTIES
-        LINK_FLAGS "-undefined dynamic_lookup"
-    )
-    target_link_libraries(pyopengv ${Boost_LIBRARIES})
-else()
-    target_link_libraries(pyopengv
-        ${Boost_LIBRARIES}
-        ${PYTHON_LIBRARIES}
-    )
-endif()
 
 # Find whether to install python libs in site-packages or dist-packages
-execute_process ( COMMAND
+execute_process( COMMAND
     python -c "import distutils.sysconfig; print('dist-packages' if distutils.sysconfig.get_python_lib().endswith('dist-packages') else 'site-packages')"
     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/python/pyopengv.cpp
+++ b/python/pyopengv.cpp
@@ -1,4 +1,3 @@
-#include <boost/python.hpp>
 #include <iostream>
 #include <vector>
 #include <opengv/absolute_pose/AbsoluteAdapterBase.hpp>
@@ -14,53 +13,33 @@
 
 #include "types.hpp"
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/ndarrayobject.h>
-
-#if (PY_VERSION_HEX < 0x03000000)
-static void numpy_import_array_wrapper()
-#else
-static int* numpy_import_array_wrapper()
-#endif
-{
-  /* Initialise numpy API and use 2/3 compatible return */
-  import_array();
-}
-
-
-
 
 namespace pyopengv {
 
-namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
-
-typedef PyArrayContiguousView<double> pyarray_t;
-
 
 opengv::bearingVector_t bearingVectorFromArray(
-    const pyarray_t &array,
+    const pyarray_d &array,
     size_t index )
 {
   opengv::bearingVector_t v;
-  v[0] = array.get(index, 0);
-  v[1] = array.get(index, 1);
-  v[2] = array.get(index, 2);
+  v[0] = *array.data(index, 0);
+  v[1] = *array.data(index, 1);
+  v[2] = *array.data(index, 2);
   return v;
 }
 
 opengv::point_t pointFromArray(
-    const pyarray_t &array,
+    const pyarray_d &array,
     size_t index )
 {
   opengv::point_t p;
-  p[0] = array.get(index, 0);
-  p[1] = array.get(index, 1);
-  p[2] = array.get(index, 2);
+  p[0] = *array.data(index, 0);
+  p[1] = *array.data(index, 1);
+  p[2] = *array.data(index, 2);
   return p;
 }
 
-bp::object arrayFromPoints( const opengv::points_t &points )
+py::object arrayFromPoints( const opengv::points_t &points )
 {
   std::vector<double> data(points.size() * 3);
   for (size_t i = 0; i < points.size(); ++i) {
@@ -68,58 +47,53 @@ bp::object arrayFromPoints( const opengv::points_t &points )
     data[3 * i + 1] = points[i][1];
     data[3 * i + 2] = points[i][2];
   }
-  npy_intp shape[2] = {(npy_intp)points.size(), 3};
-  return bpn_array_from_data(2, shape, &data[0]);
+  return py_array_from_data(&data[0], points.size(), 3);
 }
 
-bp::object arrayFromTranslation( const opengv::translation_t &t )
+py::object arrayFromTranslation( const opengv::translation_t &t )
 {
-  npy_intp shape[1] = {3};
-  return bpn_array_from_data(1, shape, t.data());
+  return py_array_from_data(t.data(), 3);
 }
 
-bp::object arrayFromRotation( const opengv::rotation_t &R )
+py::object arrayFromRotation( const opengv::rotation_t &R )
 {
   Eigen::Matrix<double, 3, 3, Eigen::RowMajor> R_row_major = R;
-  npy_intp shape[2] = {3, 3};
-  return bpn_array_from_data(2, shape, R_row_major.data());
+  return py_array_from_data(R_row_major.data(), 3, 3);
 }
 
-bp::list listFromRotations( const opengv::rotations_t &Rs )
+py::list listFromRotations( const opengv::rotations_t &Rs )
 {
-  bp::list retn;
+  py::list retn;
   for (size_t i = 0; i < Rs.size(); ++i) {
     retn.append(arrayFromRotation(Rs[i]));
   }
   return retn;
 }
 
-bp::object arrayFromEssential( const opengv::essential_t &E )
+py::object arrayFromEssential( const opengv::essential_t &E )
 {
   Eigen::Matrix<double, 3, 3, Eigen::RowMajor> E_row_major = E;
-  npy_intp shape[2] = {3, 3};
-  return bpn_array_from_data(2, shape, E_row_major.data());
+  return py_array_from_data(E_row_major.data(), 3, 3);
 }
 
-bp::list listFromEssentials( const opengv::essentials_t &Es )
+py::list listFromEssentials( const opengv::essentials_t &Es )
 {
-  bp::list retn;
+  py::list retn;
   for (size_t i = 0; i < Es.size(); ++i) {
     retn.append(arrayFromEssential(Es[i]));
   }
   return retn;
 }
 
-bp::object arrayFromTransformation( const opengv::transformation_t &t )
+py::object arrayFromTransformation( const opengv::transformation_t &t )
 {
   Eigen::Matrix<double, 3, 4, Eigen::RowMajor> t_row_major = t;
-  npy_intp shape[2] = {3, 4};
-  return bpn_array_from_data(2, shape, t_row_major.data());
+  return py_array_from_data(t_row_major.data(), 3, 4);
 }
 
-bp::list listFromTransformations( const opengv::transformations_t &t )
+py::list listFromTransformations( const opengv::transformations_t &t )
 {
-  bp::list retn;
+  py::list retn;
   for (size_t i = 0; i < t.size(); ++i) {
     retn.append(arrayFromTransformation(t[i]));
   }
@@ -147,43 +121,40 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CentralAbsoluteAdapter(
-      bpn::array & bearingVectors,
-      bpn::array & points )
+      pyarray_d &bearingVectors,
+      pyarray_d &points )
     : _bearingVectors(bearingVectors)
     , _points(points)
   {}
 
   CentralAbsoluteAdapter(
-      bpn::array & bearingVectors,
-      bpn::array & points,
-      bpn::array & R )
+      pyarray_d &bearingVectors,
+      pyarray_d &points,
+      pyarray_d &R )
     : _bearingVectors(bearingVectors)
     , _points(points)
   {
-    pyarray_t R_view(R);
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-        _R(i, j) = R_view.get(i, j);
+        _R(i, j) = *R.data(i, j);
       }
     }
   }
 
   CentralAbsoluteAdapter(
-      bpn::array & bearingVectors,
-      bpn::array & points,
-      bpn::array & t,
-      bpn::array & R )
+      pyarray_d &bearingVectors,
+      pyarray_d &points,
+      pyarray_d &t,
+      pyarray_d &R )
     : _bearingVectors(bearingVectors)
     , _points(points)
   {
-    pyarray_t t_view(t);
     for (int i = 0; i < 3; ++i) {
-      _t(i) = t_view.get(i);
+      _t(i) = *t.data(i);
     }
-    pyarray_t R_view(R);
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-        _R(i, j) = R_view.get(i, j);
+        _R(i, j) = *R.data(i, j);
       }
     }
   }
@@ -217,77 +188,78 @@ public:
   }
 
 protected:
-  pyarray_t _bearingVectors;
-  pyarray_t _points;
+  pyarray_d _bearingVectors;
+  pyarray_d _points;
 };
 
 
 
-bp::object p2p( bpn::array &v, bpn::array &p, bpn::array &R )
+py::object p2p( pyarray_d &v, pyarray_d &p, pyarray_d &R )
 {
   CentralAbsoluteAdapter adapter(v, p, R);
   return arrayFromTranslation(
     opengv::absolute_pose::p2p(adapter, 0, 1));
 }
 
-bp::object p3p_kneip( bpn::array &v, bpn::array &p )
+py::object p3p_kneip( pyarray_d &v, pyarray_d &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::p3p_kneip(adapter, 0, 1, 2));
 }
 
-bp::object p3p_gao( bpn::array &v, bpn::array &p )
+py::object p3p_gao( pyarray_d &v, pyarray_d &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::p3p_gao(adapter, 0, 1, 2));
 }
 
-bp::object gp3p( bpn::array &v, bpn::array &p )
+py::object gp3p( pyarray_d &v, pyarray_d &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::gp3p(adapter, 0, 1, 2));
 }
 
-bp::object epnp( bpn::array &v, bpn::array &p )
+py::object epnp( pyarray_d &v, pyarray_d &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return arrayFromTransformation(
     opengv::absolute_pose::epnp(adapter));
 }
 
-bp::object gpnp( bpn::array &v, bpn::array &p )
+py::object gpnp( pyarray_d &v, pyarray_d &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return arrayFromTransformation(
     opengv::absolute_pose::gpnp(adapter));
 }
 
-bp::object upnp( bpn::array &v, bpn::array &p )
+py::object upnp( pyarray_d &v, pyarray_d &p )
 {
   CentralAbsoluteAdapter adapter(v, p);
   return listFromTransformations(
     opengv::absolute_pose::upnp(adapter));
 }
 
-bp::object optimize_nonlinear( bpn::array &v,
-                               bpn::array &p,
-                               bpn::array &t,
-                               bpn::array &R )
+py::object optimize_nonlinear( pyarray_d &v,
+                               pyarray_d &p,
+                               pyarray_d &t,
+                               pyarray_d &R )
 {
   CentralAbsoluteAdapter adapter(v, p, t, R);
   return arrayFromTransformation(
     opengv::absolute_pose::optimize_nonlinear(adapter));
 }
 
-bp::object ransac(
-    bpn::array &v,
-    bpn::array &p,
+py::object ransac(
+    pyarray_d &v,
+    pyarray_d &p,
     std::string algo_name,
     double threshold,
-    int max_iterations )
+    int max_iterations,
+    double probability )
 {
   using namespace opengv::sac_problems::absolute_pose;
 
@@ -311,18 +283,20 @@ bp::object ransac(
   ransac.sac_model_ = absposeproblem_ptr;
   ransac.threshold_ = threshold;
   ransac.max_iterations_ = max_iterations;
+  ransac.probability_ = probability;
 
   // Solve
   ransac.computeModel();
   return arrayFromTransformation(ransac.model_coefficients_);
 }
 
-bp::object lmeds(
-    bpn::array &v,
-    bpn::array &p,
+py::object lmeds(
+    pyarray_d &v,
+    pyarray_d &p,
     std::string algo_name,
     double threshold,
-    int max_iterations )
+    int max_iterations,
+    double probability )
 {
   using namespace opengv::sac_problems::absolute_pose;
 
@@ -346,6 +320,7 @@ bp::object lmeds(
   lmeds.sac_model_ = absposeproblem_ptr;
   lmeds.threshold_ = threshold;
   lmeds.max_iterations_ = max_iterations;
+  lmeds.probability_ = probability;
 
   // Solve
   lmeds.computeModel();
@@ -368,43 +343,40 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CentralRelativeAdapter(
-      bpn::array & bearingVectors1,
-      bpn::array & bearingVectors2 )
+      pyarray_d &bearingVectors1,
+      pyarray_d &bearingVectors2 )
     : _bearingVectors1(bearingVectors1)
     , _bearingVectors2(bearingVectors2)
   {}
 
   CentralRelativeAdapter(
-      bpn::array & bearingVectors1,
-      bpn::array & bearingVectors2,
-      bpn::array & R12 )
+      pyarray_d &bearingVectors1,
+      pyarray_d &bearingVectors2,
+      pyarray_d &R12 )
     : _bearingVectors1(bearingVectors1)
     , _bearingVectors2(bearingVectors2)
   {
-    pyarray_t R12_view(R12);
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-        _R12(i, j) = R12_view.get(i, j);
+        _R12(i, j) = *R12.data(i, j);
       }
     }
   }
 
   CentralRelativeAdapter(
-      bpn::array & bearingVectors1,
-      bpn::array & bearingVectors2,
-      bpn::array & t12,
-      bpn::array & R12 )
+      pyarray_d &bearingVectors1,
+      pyarray_d &bearingVectors2,
+      pyarray_d &t12,
+      pyarray_d &R12 )
     : _bearingVectors1(bearingVectors1)
     , _bearingVectors2(bearingVectors2)
   {
-    pyarray_t t12_view(t12);
     for (int i = 0; i < 3; ++i) {
-      _t12(i) = t12_view.get(i);
+      _t12(i) = *t12.data(i);
     }
-    pyarray_t R12_view(R12);
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-        _R12(i, j) = R12_view.get(i, j);
+        _R12(i, j) = *R12.data(i, j);
       }
     }
   }
@@ -444,90 +416,91 @@ public:
   }
 
 protected:
-  pyarray_t _bearingVectors1;
-  pyarray_t _bearingVectors2;
+  pyarray_d _bearingVectors1;
+  pyarray_d _bearingVectors2;
 };
 
 
-bp::object twopt( bpn::array &b1, bpn::array &b2, bpn::array &R )
+py::object twopt( pyarray_d &b1, pyarray_d &b2, pyarray_d &R )
 {
   CentralRelativeAdapter adapter(b1, b2, R);
   return arrayFromTranslation(
     opengv::relative_pose::twopt(adapter, true, 0, 1));
 }
 
-bp::object twopt_rotationOnly( bpn::array &b1, bpn::array &b2 )
+py::object twopt_rotationOnly( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return arrayFromRotation(
     opengv::relative_pose::twopt_rotationOnly(adapter, 0, 1));
 }
 
-bp::object rotationOnly( bpn::array &b1, bpn::array &b2 )
+py::object rotationOnly( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return arrayFromRotation(
     opengv::relative_pose::rotationOnly(adapter));
 }
 
-bp::object fivept_nister( bpn::array &b1, bpn::array &b2 )
+py::object fivept_nister( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromEssentials(
     opengv::relative_pose::fivept_nister(adapter));
 }
 
-bp::object fivept_kneip( bpn::array &b1, bpn::array &b2 )
+py::object fivept_kneip( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromRotations(
     opengv::relative_pose::fivept_kneip(adapter, getNindices(5)));
 }
 
-bp::object sevenpt( bpn::array &b1, bpn::array &b2 )
+py::object sevenpt( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromEssentials(
     opengv::relative_pose::sevenpt(adapter));
 }
 
-bp::object eightpt( bpn::array &b1, bpn::array &b2 )
+py::object eightpt( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return arrayFromEssential(
     opengv::relative_pose::eightpt(adapter));
 }
 
-bp::object eigensolver( bpn::array &b1, bpn::array &b2, bpn::array &R )
+py::object eigensolver( pyarray_d &b1, pyarray_d &b2, pyarray_d &R )
 {
   CentralRelativeAdapter adapter(b1, b2, R);
   return arrayFromRotation(
     opengv::relative_pose::eigensolver(adapter));
 }
 
-bp::object sixpt( bpn::array &b1, bpn::array &b2 )
+py::object sixpt( pyarray_d &b1, pyarray_d &b2 )
 {
   CentralRelativeAdapter adapter(b1, b2);
   return listFromRotations(
     opengv::relative_pose::sixpt(adapter));
 }
 
-bp::object optimize_nonlinear( bpn::array &b1,
-                               bpn::array &b2,
-                               bpn::array &t12,
-                               bpn::array &R12 )
+py::object optimize_nonlinear( pyarray_d &b1,
+                               pyarray_d &b2,
+                               pyarray_d &t12,
+                               pyarray_d &R12 )
 {
   CentralRelativeAdapter adapter(b1, b2, t12, R12);
   return arrayFromTransformation(
     opengv::relative_pose::optimize_nonlinear(adapter));
 }
 
-bp::object ransac(
-    bpn::array &b1,
-    bpn::array &b2,
+py::object ransac(
+    pyarray_d &b1,
+    pyarray_d &b2,
     std::string algo_name,
     double threshold,
-    int max_iterations )
+    int max_iterations,
+    double probability )
 {
   using namespace opengv::sac_problems::relative_pose;
 
@@ -550,18 +523,20 @@ bp::object ransac(
   ransac.sac_model_ = relposeproblem_ptr;
   ransac.threshold_ = threshold;
   ransac.max_iterations_ = max_iterations;
+  ransac.probability_ = probability;
 
   // Solve
   ransac.computeModel();
   return arrayFromTransformation(ransac.model_coefficients_);
 }
 
-bp::object lmeds(
-    bpn::array &b1,
-    bpn::array &b2,
+py::object lmeds(
+    pyarray_d &b1,
+    pyarray_d &b2,
     std::string algo_name,
     double threshold,
-    int max_iterations )
+    int max_iterations,
+    double probability )
 {
   using namespace opengv::sac_problems::relative_pose;
 
@@ -584,17 +559,19 @@ bp::object lmeds(
   lmeds.sac_model_ = relposeproblem_ptr;
   lmeds.threshold_ = threshold;
   lmeds.max_iterations_ = max_iterations;
+  lmeds.probability_ = probability;
 
   // Solve
   lmeds.computeModel();
   return arrayFromTransformation(lmeds.model_coefficients_);
 }
 
-bp::object ransac_rotationOnly(
-    bpn::array &b1,
-    bpn::array &b2,
+py::object ransac_rotationOnly(
+    pyarray_d &b1,
+    pyarray_d &b2,
     double threshold,
-    int max_iterations )
+    int max_iterations,
+    double probability )
 {
   using namespace opengv::sac_problems::relative_pose;
 
@@ -610,17 +587,19 @@ bp::object ransac_rotationOnly(
   ransac.sac_model_ = relposeproblem_ptr;
   ransac.threshold_ = threshold;
   ransac.max_iterations_ = max_iterations;
+  ransac.probability_ = probability;
 
   // Solve
   ransac.computeModel();
   return arrayFromRotation(ransac.model_coefficients_);
 }
 
-bp::object lmeds_rotationOnly(
-    bpn::array &b1,
-    bpn::array &b2,
+py::object lmeds_rotationOnly(
+    pyarray_d &b1,
+    pyarray_d &b2,
     double threshold,
-    int max_iterations )
+    int max_iterations,
+    double probability )
 {
   using namespace opengv::sac_problems::relative_pose;
 
@@ -636,6 +615,7 @@ bp::object lmeds_rotationOnly(
   lmeds.sac_model_ = relposeproblem_ptr;
   lmeds.threshold_ = threshold;
   lmeds.max_iterations_ = max_iterations;
+  lmeds.probability_ = probability;
 
   // Solve
   lmeds.computeModel();
@@ -647,10 +627,10 @@ bp::object lmeds_rotationOnly(
 namespace triangulation
 {
 
-bp::object triangulate( bpn::array &b1,
-                        bpn::array &b2,
-                        bpn::array &t12,
-                        bpn::array &R12 )
+py::object triangulate( pyarray_d &b1,
+                        pyarray_d &b2,
+                        pyarray_d &t12,
+                        pyarray_d &R12 )
 {
   pyopengv::relative_pose::CentralRelativeAdapter adapter(b1, b2, t12, R12);
 
@@ -663,10 +643,10 @@ bp::object triangulate( bpn::array &b1,
   return arrayFromPoints(points);
 }
 
-bp::object triangulate2( bpn::array &b1,
-                         bpn::array &b2,
-                         bpn::array &t12,
-                         bpn::array &R12 )
+py::object triangulate2( pyarray_d &b1,
+                         pyarray_d &b2,
+                         pyarray_d &t12,
+                         pyarray_d &R12 )
 {
   pyopengv::relative_pose::CentralRelativeAdapter adapter(b1, b2, t12, R12);
 
@@ -684,38 +664,78 @@ bp::object triangulate2( bpn::array &b1,
 
 } // namespace pyopengv
 
-BOOST_PYTHON_MODULE(pyopengv) {
-  using namespace boost::python;
 
-  boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
-  numpy_import_array_wrapper();
+PYBIND11_MODULE(pyopengv, m) {
+  namespace py = pybind11;
 
-  def("absolute_pose_p2p", pyopengv::absolute_pose::p2p);
-  def("absolute_pose_p3p_kneip", pyopengv::absolute_pose::p3p_kneip);
-  def("absolute_pose_p3p_gao", pyopengv::absolute_pose::p3p_gao);
-  def("absolute_pose_gp3p", pyopengv::absolute_pose::gp3p);
-  def("absolute_pose_epnp", pyopengv::absolute_pose::epnp);
-  def("absolute_pose_gpnp", pyopengv::absolute_pose::gpnp);
-  def("absolute_pose_upnp", pyopengv::absolute_pose::upnp);
-  def("absolute_pose_optimize_nonlinear", pyopengv::absolute_pose::optimize_nonlinear);
-  def("absolute_pose_ransac", pyopengv::absolute_pose::ransac);
-  def("absolute_pose_lmeds", pyopengv::absolute_pose::lmeds);
+  m.def("absolute_pose_p2p", pyopengv::absolute_pose::p2p);
+  m.def("absolute_pose_p3p_kneip", pyopengv::absolute_pose::p3p_kneip);
+  m.def("absolute_pose_p3p_gao", pyopengv::absolute_pose::p3p_gao);
+  m.def("absolute_pose_gp3p", pyopengv::absolute_pose::gp3p);
+  m.def("absolute_pose_epnp", pyopengv::absolute_pose::epnp);
+  m.def("absolute_pose_gpnp", pyopengv::absolute_pose::gpnp);
+  m.def("absolute_pose_upnp", pyopengv::absolute_pose::upnp);
+  m.def("absolute_pose_optimize_nonlinear", pyopengv::absolute_pose::optimize_nonlinear);
+  m.def("absolute_pose_ransac", pyopengv::absolute_pose::ransac,
+        py::arg("v"),
+        py::arg("p"),
+        py::arg("algo_name"),
+        py::arg("threshold"),
+        py::arg("iterations") = 1000,
+        py::arg("probability") = 0.99
+  );
+  m.def("absolute_pose_lmeds", pyopengv::absolute_pose::lmeds,
+        py::arg("v"),
+        py::arg("p"),
+        py::arg("algo_name"),
+        py::arg("threshold"),
+        py::arg("iterations") = 1000,
+        py::arg("probability") = 0.99
+  );
 
-  def("relative_pose_twopt", pyopengv::relative_pose::twopt);
-  def("relative_pose_twopt_rotation_only", pyopengv::relative_pose::twopt_rotationOnly);
-  def("relative_pose_rotation_only", pyopengv::relative_pose::rotationOnly);
-  def("relative_pose_fivept_nister", pyopengv::relative_pose::fivept_nister);
-  def("relative_pose_fivept_kneip", pyopengv::relative_pose::fivept_kneip);
-  def("relative_pose_sevenpt", pyopengv::relative_pose::sevenpt);
-  def("relative_pose_eightpt", pyopengv::relative_pose::eightpt);
-  def("relative_pose_eigensolver", pyopengv::relative_pose::eigensolver);
-  def("relative_pose_sixpt", pyopengv::relative_pose::sixpt);
-  def("relative_pose_optimize_nonlinear", pyopengv::relative_pose::optimize_nonlinear);
-  def("relative_pose_ransac", pyopengv::relative_pose::ransac);
-  def("relative_pose_ransac_rotation_only", pyopengv::relative_pose::ransac_rotationOnly);
-  def("relative_pose_lmeds", pyopengv::relative_pose::lmeds);
-  def("relative_pose_lmeds_rotation_only", pyopengv::relative_pose::lmeds_rotationOnly);
+  m.def("relative_pose_twopt", pyopengv::relative_pose::twopt);
+  m.def("relative_pose_twopt_rotation_only", pyopengv::relative_pose::twopt_rotationOnly);
+  m.def("relative_pose_rotation_only", pyopengv::relative_pose::rotationOnly);
+  m.def("relative_pose_fivept_nister", pyopengv::relative_pose::fivept_nister);
+  m.def("relative_pose_fivept_kneip", pyopengv::relative_pose::fivept_kneip);
+  m.def("relative_pose_sevenpt", pyopengv::relative_pose::sevenpt);
+  m.def("relative_pose_eightpt", pyopengv::relative_pose::eightpt);
+  m.def("relative_pose_eigensolver", pyopengv::relative_pose::eigensolver);
+  m.def("relative_pose_sixpt", pyopengv::relative_pose::sixpt);
+  m.def("relative_pose_optimize_nonlinear", pyopengv::relative_pose::optimize_nonlinear);
+  m.def("relative_pose_ransac", pyopengv::relative_pose::ransac,
+        py::arg("b1"),
+        py::arg("b2"),
+        py::arg("algo_name"),
+        py::arg("threshold"),
+        py::arg("iterations") = 1000,
+        py::arg("probability") = 0.99
+  );
+  m.def("relative_pose_lmeds", pyopengv::relative_pose::lmeds,
+        py::arg("b1"),
+        py::arg("b2"),
+        py::arg("algo_name"),
+        py::arg("threshold"),
+        py::arg("iterations") = 1000,
+        py::arg("probability") = 0.99
+  );
+  m.def("relative_pose_ransac_rotation_only", pyopengv::relative_pose::ransac_rotationOnly,
+        py::arg("b1"),
+        py::arg("b2"),
+        py::arg("threshold"),
+        py::arg("iterations") = 1000,
+        py::arg("probability") = 0.99
+  );
+  m.def("relative_pose_lmeds_rotation_only", pyopengv::relative_pose::lmeds_rotationOnly,
+        py::arg("b1"),
+        py::arg("b2"),
+        py::arg("threshold"),
+        py::arg("iterations") = 1000,
+        py::arg("probability") = 0.99
+  );
 
-  def("triangulation_triangulate", pyopengv::triangulation::triangulate);
-  def("triangulation_triangulate2", pyopengv::triangulation::triangulate2);
+
+
+  m.def("triangulation_triangulate", pyopengv::triangulation::triangulate);
+  m.def("triangulation_triangulate2", pyopengv::triangulation::triangulate2);
 }

--- a/python/types.hpp
+++ b/python/types.hpp
@@ -1,115 +1,39 @@
 #ifndef __TYPES_H__
 #define __TYPES_H__
 
-#include <boost/python.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
 #include <vector>
 #include <iostream>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/ndarrayobject.h>
 
 namespace pyopengv {
 
-namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
+namespace py = pybind11;
 
-template <typename T> inline int numpy_typenum() {}
-template <> inline int numpy_typenum<bool>() { return NPY_BOOL; }
-template <> inline int numpy_typenum<char>() { return NPY_INT8; }
-template <> inline int numpy_typenum<short>() { return NPY_INT16; }
-template <> inline int numpy_typenum<int>() { return NPY_INT32; }
-template <> inline int numpy_typenum<long long>() { return NPY_INT64; }
-template <> inline int numpy_typenum<unsigned char>() { return NPY_UINT8; }
-template <> inline int numpy_typenum<unsigned short>() { return NPY_UINT16; }
-template <> inline int numpy_typenum<unsigned int>() { return NPY_UINT32; }
-template <> inline int numpy_typenum<unsigned long long>() { return NPY_UINT64; }
-template <> inline int numpy_typenum<float>() { return NPY_FLOAT32; }
-template <> inline int numpy_typenum<double>() { return NPY_FLOAT64; }
-
-template <typename T> inline const char *type_string() {}
-template <> inline const char *type_string<bool>() { return "bool"; }
-template <> inline const char *type_string<char>() { return "int8"; }
-template <> inline const char *type_string<short>() { return "int16"; }
-template <> inline const char *type_string<int>() { return "int32"; }
-template <> inline const char *type_string<long long>() { return "int64"; }
-template <> inline const char *type_string<unsigned char>() { return "uint8"; }
-template <> inline const char *type_string<unsigned short>() { return "uint16"; }
-template <> inline const char *type_string<unsigned int>() { return "uint32"; }
-template <> inline const char *type_string<unsigned long long>() { return "uint64"; }
-template <> inline const char *type_string<float>() { return "float32"; }
-template <> inline const char *type_string<double>() { return "float64"; }
+typedef py::array_t<double, py::array::c_style | py::array::forcecast> pyarray_d;
 
 template <typename T>
-bp::object bpn_array_from_data(int nd, npy_intp *shape, const T *data) {
-  PyObject *pyarray = PyArray_SimpleNewFromData(
-      nd, shape, numpy_typenum<T>(), (void *)data);
-  bp::handle<> handle(pyarray);
-  return bpn::array(handle).copy(); // copy the object. numpy owns the copy now.
+py::array_t<T> py_array_from_data(const T *data, size_t shape0) {
+  py::array_t<T> res({shape0});
+  std::copy(data, data + shape0, res.mutable_data());
+  return res;
 }
 
 template <typename T>
-bp::object bpn_array_from_vector(const std::vector<T> &v) {
-  npy_intp shape[] = { v.size() };
+py::array_t<T> py_array_from_data(const T *data, size_t shape0, size_t shape1) {
+  py::array_t<T> res({shape0, shape1});
+  std::copy(data, data + shape0 * shape1, res.mutable_data());
+  return res;
+}
+
+template <typename T>
+py::array_t<T> py_array_from_vector(const std::vector<T> &v) {
   const T *data = v.size() ? &v[0] : NULL;
-  return bpn_array_from_data(1, shape, data);
+  return py_array_from_data(data, v.size());
 }
 
-template<typename T>
-class PyArrayContiguousView {
- public:
-  PyArrayContiguousView(bpn::array &array) {
-    init((PyArrayObject *)array.ptr());
-  }
-
-  PyArrayContiguousView(bp::object &object) {
-    init((PyArrayObject *)object.ptr());
-  }
-
-  PyArrayContiguousView(PyArrayObject *object) {
-    init(object);
-  }
-
-  ~PyArrayContiguousView() {
-    if (contiguous_) Py_DECREF(contiguous_);
-  }
-
-  const T *data() const {
-    return (T *)PyArray_DATA(contiguous_);
-  }
-
-  int ndim() const {
-    return PyArray_NDIM(contiguous_);
-  }
-
-  int shape(int dim) const {
-    return PyArray_DIMS(contiguous_)[dim];
-  }
-
-  bool valid() const {
-    return contiguous_ != NULL;
-  }
-
-  T get(size_t i) const {
-    return data()[i];
-  }
-
-  T get(size_t i, size_t j) const {
-    return data()[i * shape(1) + j];
-  }
-
- private:
-  void init(PyArrayObject *object) {
-    int type = PyArray_DESCR(object)->type_num;
-    if (type != numpy_typenum<T>()) {
-      std::cerr << "Error in PyArrayContiguousView: expected array of type " << type_string<T>() << std::endl;
-      contiguous_ = NULL;
-    } else {
-      contiguous_ = (PyArrayObject *)PyArray_ContiguousFromAny((PyObject *)object, numpy_typenum<T>(), 0, 0);
-    }
-  };
-
-  PyArrayObject *contiguous_;
-};
 
 }
 


### PR DESCRIPTION
This PR updates the python wrappers to use pybind11 instead of boost python.

Boost python wrappers have been difficult to maintain for different versions of boost and python. Pybind11 works with all python versions and is included as a submodule to make sure everyone uses the same version.

The changes are similar to https://github.com/laurentkneip/opengv/pull/69 but use more of pybind11 build-in functionality and completely drop the boost python option so that there is only one wrapper.