### PR TITLE
Detect where to install the python module

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,13 +8,15 @@ pybind11_add_module(pyopengv pyopengv.cpp)
 target_link_libraries(pyopengv PRIVATE opengv)
 
 
-# Find whether to install python libs in site-packages or dist-packages
-execute_process( COMMAND
-    python -c "import distutils.sysconfig; print('dist-packages' if distutils.sysconfig.get_python_lib().endswith('dist-packages') else 'site-packages')"
+# Find where to install python libs.
+execute_process(COMMAND
+    ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig; print('/'.join(distutils.sysconfig.get_python_lib().split('/')[-3:]))"
     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 set(PYTHON_INSTALL_DIR
-    "${CMAKE_INSTALL_PREFIX}/lib/python2.7/${PYTHON_SITE_PACKAGES}"
+    "${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES}"
     CACHE PATH "Path where to install pyopengv")
 
 install(TARGETS pyopengv DESTINATION "${PYTHON_INSTALL_DIR}")
+
+message(python executable ${PYTHON_EXECUTABLE})


### PR DESCRIPTION
This PR stops assuming we are using Python 2 and uses `${PYTHON_EXECUTABLE}` instead to find where to install the `pyopengv` module.

The detected location can still be overriden by setting the `PYTHON_INSTALL_DIR` cmake option.