### PR TITLE
Add option to set target architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,7 @@ IF(MSVC)
   add_compile_options(/wd4514 /wd4267 /bigobj)
   add_definitions(-D_USE_MATH_DEFINES)
 ELSE()
-  IF (CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(ARM64)|(aarch64)|(AARCH64)")
-    add_definitions (-march=armv8-a)
-  ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES 
-          "(arm)|(ARM)|(armhf)|(ARMHF)|(armel)|(ARMEL)")
-    add_definitions (-march=armv7-a)
-  ELSE ()
-    add_definitions (-march=native) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
-  ENDIF()
+  set(BUILD_ARCH "native" CACHE STRING "Architecture to build for.  It will be used to set gcc's -march option")
   add_definitions (
     -O3
     -Wall
@@ -46,6 +39,7 @@ ELSE()
     -Wwrite-strings
     -Wno-unused-parameter
     -fno-strict-aliasing
+    -march=${BUILD_ARCH}
   )
 ENDIF()
 
@@ -185,7 +179,7 @@ set_target_properties( opengv random_generators PROPERTIES
                     CXX_STANDARD_REQUIRED ON
                     DEBUG_POSTFIX d )
 
-target_include_directories( opengv PUBLIC 
+target_include_directories( opengv PUBLIC
                 # only when building from the source tree
                 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
                 # only when using the lib from the install path
@@ -384,8 +378,8 @@ install(EXPORT "${targets_export_name}"
         DESTINATION "${config_install_dir}")
 
 # Headers
-install(DIRECTORY include/ 
-        DESTINATION ${include_install_dir} 
+install(DIRECTORY include/
+        DESTINATION ${include_install_dir}
         FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
 
 


### PR DESCRIPTION
This PR adds a cmake option to choose the target architecture for the build. This lets the user chose the architecture of the build independently of the current architecture.

It also removes the logic that tries to select the best architecture based on the `CMAKE_SYSTEM_PROCESSOR`. Letting the user do this selection is simpler and more flexible.