### PR TITLE
[ci] Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ addons:
     packages:
         - build-essential 
         - python-dev 
+        - python3-dev 
         - libboost-python-dev 
         - python-numpy-dev
+        - python3-numpy-dev
         - libeigen3-dev
 
 env:
@@ -50,9 +52,9 @@ before_script:
   - cd build
   - >
      if [ $CXX = "clang++" ]; then
-        cmake .. -DBUILD_TESTS:BOOL=ON -DBUILD_PYTHON:BOOL=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-register"
+        cmake .. -DBUILD_TESTS:BOOL=ON -DBUILD_PYTHON:BOOL=ON -DPYBIND11_PYTHON_VERSION=3.4 -DCMAKE_CXX_FLAGS="-Wno-deprecated-register -Wno-deprecated-declarations" 
      else
-        cmake .. -DBUILD_TESTS:BOOL=ON -DBUILD_PYTHON:BOOL=ON
+        cmake .. -DBUILD_TESTS:BOOL=ON -DBUILD_PYTHON:BOOL=ON -DPYBIND11_PYTHON_VERSION=3.4
      fi
 
 script:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+set(PYBIND11_CPP_STANDARD -std=c++11)
 add_subdirectory(pybind11)
 
 include_directories(${PYTHON_INCLUDE_DIRS})


### PR DESCRIPTION
The CI on travis was broken because of the default version of python to use. Now it is building with 3.4 shipped with trusty .

Moreover since the library is built with c++11 also the python bindings are now built with that standard.

S.