### PR TITLE
Comment out unused argument to avoid compiler warnings.

### DIFF
--- a/include/opengv/sac/implementation/SampleConsensusProblem.hpp
+++ b/include/opengv/sac/implementation/SampleConsensusProblem.hpp
@@ -54,7 +54,7 @@ opengv::sac::SampleConsensusProblem<M>::~SampleConsensusProblem()
 
 template<typename M>
 bool opengv::sac::SampleConsensusProblem<M>::isSampleGood(
-    const std::vector<int> & sample) const
+    const std::vector<int> & /* sample */) const
 {
   // Default implementation
   return true;


### PR DESCRIPTION
On gcc, compiler warnings are generated for this unused function parameter. This fix avoids the warning from being triggered.