### PR TITLE
[cmake] allow to override the cxx standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,6 @@ IF(MSVC)
   add_compile_options(/wd4514 /wd4267 /bigobj)
   add_definitions(-D_USE_MATH_DEFINES)
 ELSE()
-  IF (CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(ARM64)|(aarch64)|(AARCH64)")
-    add_definitions (-march=armv8-a)
-  ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES 
-          "(arm)|(ARM)|(armhf)|(ARMHF)|(armel)|(ARMEL)")
-    add_definitions (-march=armv7-a)
-  ELSE ()
-    add_definitions (-march=native) #TODO use correct c++11 def once everybody has moved to gcc 4.7 # for now I even removed std=gnu++0x
-  ENDIF()
   add_definitions (
     -O3
     -Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ ELSE()
   OPTION(BUILD_POSITION_INDEPENDENT_CODE "Build position independent code (-fPIC)" ON)
 ENDIF()
 
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "The C++ standard used by the project")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 IF(MSVC)
   add_compile_options(/wd4514 /wd4267 /bigobj)
   add_definitions(-D_USE_MATH_DEFINES)
@@ -181,8 +184,6 @@ add_library( random_generators test/random_generators.cpp test/random_generators
 set_target_properties( opengv random_generators PROPERTIES
                     SOVERSION ${PROJECT_VERSION}
                     VERSION ${PROJECT_VERSION}
-                    CXX_STANDARD 11
-                    CXX_STANDARD_REQUIRED ON
                     DEBUG_POSTFIX d )
 
 target_include_directories( opengv PUBLIC 

--- a/src/absolute_pose/CentralAbsoluteAdapter.cpp
+++ b/src/absolute_pose/CentralAbsoluteAdapter.cpp
@@ -31,6 +31,7 @@
 
 #include <opengv/absolute_pose/CentralAbsoluteAdapter.hpp>
 
+#include <cassert>
 
 opengv::absolute_pose::CentralAbsoluteAdapter::CentralAbsoluteAdapter(
     const bearingVectors_t & bearingVectors,

--- a/src/absolute_pose/MACentralAbsolute.cpp
+++ b/src/absolute_pose/MACentralAbsolute.cpp
@@ -31,6 +31,7 @@
 
 #include <opengv/absolute_pose/MACentralAbsolute.hpp>
 
+#include <cassert>
 
 opengv::absolute_pose::MACentralAbsolute::MACentralAbsolute(
     const double * points,

--- a/src/absolute_pose/MANoncentralAbsolute.cpp
+++ b/src/absolute_pose/MANoncentralAbsolute.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/absolute_pose/MANoncentralAbsolute.hpp>
 
+#include <cassert>
+
 opengv::absolute_pose::MANoncentralAbsolute::MANoncentralAbsolute(
     const double * points,
     const double * bearingVectors,

--- a/src/absolute_pose/NoncentralAbsoluteAdapter.cpp
+++ b/src/absolute_pose/NoncentralAbsoluteAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/absolute_pose/NoncentralAbsoluteAdapter.hpp>
 
+#include <cassert>
+
 opengv::absolute_pose::NoncentralAbsoluteAdapter::NoncentralAbsoluteAdapter(
     const bearingVectors_t & bearingVectors,
     const camCorrespondences_t & camCorrespondences,

--- a/src/absolute_pose/NoncentralAbsoluteMultiAdapter.cpp
+++ b/src/absolute_pose/NoncentralAbsoluteMultiAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/absolute_pose/NoncentralAbsoluteMultiAdapter.hpp>
 
+#include <cassert>
+
 opengv::absolute_pose::NoncentralAbsoluteMultiAdapter::NoncentralAbsoluteMultiAdapter(
     std::vector<std::shared_ptr<bearingVectors_t> > bearingVectors,
     std::vector<std::shared_ptr<points_t> > points,

--- a/src/absolute_pose/methods.cpp
+++ b/src/absolute_pose/methods.cpp
@@ -42,6 +42,7 @@
 #include <opengv/math/quaternion.hpp>
 #include <opengv/math/roots.hpp>
 
+#include <cassert>
 #include <iostream>
 
 opengv::translation_t

--- a/src/absolute_pose/modules/main.cpp
+++ b/src/absolute_pose/modules/main.cpp
@@ -46,6 +46,8 @@
 #include <opengv/math/arun.hpp>
 #include <opengv/math/cayley.hpp>
 
+#include <cassert>
+
 void
 opengv::absolute_pose::modules::p3p_kneip_main(
     const bearingVectors_t & f,

--- a/src/math/arun.cpp
+++ b/src/math/arun.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/math/arun.hpp>
 
+#include <cassert>
+
 opengv::rotation_t
 opengv::math::arun( const Eigen::MatrixXd & Hcross )
 {

--- a/src/point_cloud/MAPointCloud.cpp
+++ b/src/point_cloud/MAPointCloud.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/point_cloud/MAPointCloud.hpp>
 
+#include <cassert>
+
 opengv::point_cloud::MAPointCloud::MAPointCloud(
     const double * points1,
     const double * points2,

--- a/src/point_cloud/PointCloudAdapter.cpp
+++ b/src/point_cloud/PointCloudAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/point_cloud/PointCloudAdapter.hpp>
 
+#include <cassert>
+
 opengv::point_cloud::PointCloudAdapter::PointCloudAdapter(
     const points_t & points1,
     const points_t & points2 ) :

--- a/src/point_cloud/methods.cpp
+++ b/src/point_cloud/methods.cpp
@@ -39,6 +39,8 @@
 #include <opengv/math/arun.hpp>
 #include <opengv/math/cayley.hpp>
 
+#include <cassert>
+
 namespace opengv
 {
 namespace point_cloud

--- a/src/relative_pose/CentralRelativeAdapter.cpp
+++ b/src/relative_pose/CentralRelativeAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/CentralRelativeAdapter.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::CentralRelativeAdapter::CentralRelativeAdapter(
     const bearingVectors_t & bearingVectors1,
     const bearingVectors_t & bearingVectors2 ) :

--- a/src/relative_pose/CentralRelativeMultiAdapter.cpp
+++ b/src/relative_pose/CentralRelativeMultiAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/CentralRelativeMultiAdapter.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::CentralRelativeMultiAdapter::CentralRelativeMultiAdapter(
     std::vector<std::shared_ptr<bearingVectors_t> > bearingVectors1,
     std::vector<std::shared_ptr<bearingVectors_t> > bearingVectors2 ) :

--- a/src/relative_pose/CentralRelativeWeightingAdapter.cpp
+++ b/src/relative_pose/CentralRelativeWeightingAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/CentralRelativeWeightingAdapter.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::CentralRelativeWeightingAdapter::CentralRelativeWeightingAdapter(
     const bearingVectors_t & bearingVectors1,
     const bearingVectors_t & bearingVectors2,

--- a/src/relative_pose/MACentralRelative.cpp
+++ b/src/relative_pose/MACentralRelative.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/MACentralRelative.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::MACentralRelative::MACentralRelative(
     const double * bearingVectors1,
     const double * bearingVectors2,

--- a/src/relative_pose/MANoncentralRelative.cpp
+++ b/src/relative_pose/MANoncentralRelative.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/MANoncentralRelative.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::MANoncentralRelative::MANoncentralRelative(
       const double * bearingVectors1,
       const double * bearingVectors2,

--- a/src/relative_pose/MANoncentralRelativeMulti.cpp
+++ b/src/relative_pose/MANoncentralRelativeMulti.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/MANoncentralRelativeMulti.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::MANoncentralRelativeMulti::MANoncentralRelativeMulti(
     const std::vector<double*> & bearingVectors1,
     const std::vector<double*> & bearingVectors2,

--- a/src/relative_pose/NoncentralRelativeAdapter.cpp
+++ b/src/relative_pose/NoncentralRelativeAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/NoncentralRelativeAdapter.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::NoncentralRelativeAdapter::NoncentralRelativeAdapter(
     const bearingVectors_t & bearingVectors1,
     const bearingVectors_t & bearingVectors2,

--- a/src/relative_pose/NoncentralRelativeMultiAdapter.cpp
+++ b/src/relative_pose/NoncentralRelativeMultiAdapter.cpp
@@ -31,6 +31,8 @@
 
 #include <opengv/relative_pose/NoncentralRelativeMultiAdapter.hpp>
 
+#include <cassert>
+
 opengv::relative_pose::NoncentralRelativeMultiAdapter::NoncentralRelativeMultiAdapter(
     std::vector<std::shared_ptr<bearingVectors_t> > bearingVectors1,
     std::vector<std::shared_ptr<bearingVectors_t> > bearingVectors2,

--- a/src/relative_pose/methods.cpp
+++ b/src/relative_pose/methods.cpp
@@ -41,6 +41,7 @@
 #include <opengv/relative_pose/modules/main.hpp>
 #include <opengv/triangulation/methods.hpp>
 
+#include <cassert>
 #include <iostream>
 
 opengv::translation_t

--- a/src/relative_pose/modules/fivept_nister/modules.cpp
+++ b/src/relative_pose/modules/fivept_nister/modules.cpp
@@ -35,6 +35,8 @@
 
 #include <opengv/OptimizationFunctor.hpp>
 
+#include <cassert>
+
 void
 opengv::relative_pose::modules::fivept_nister::composeA(
     const Eigen::Matrix<double,9,4> & EE,


### PR DESCRIPTION
When using multiple libraries using eigen, they all need to agree on the way we use memory alignment in eigen.
See https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html
As we have moved to C++17, we need all libraries using eigen to be compatible with that.

The solution is simple: define a cmake cached variable, so it can be overriden.

This PR also add some missing includes, needed to build with g++ 10.
